### PR TITLE
feat(tg): upgrade to v6.2

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -3,7 +3,7 @@ package tg
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -42,7 +42,7 @@ func TestClient_Download(t *testing.T) {
 		assert.NoError(t, err)
 		defer body.Close()
 
-		data, err := ioutil.ReadAll(body)
+		data, err := io.ReadAll(body)
 		assert.NoError(t, err)
 		assert.Equal(t, "test", string(data))
 

--- a/methods_gen.go
+++ b/methods_gen.go
@@ -5,7 +5,7 @@ package tg
 
 // GetUpdatesCall reprenesents a call to the getUpdates method.
 // Use this method to receive incoming updates using long polling (wiki)
-// An Array of Update objects is returned.
+// Returns an Array of Update objects.
 type GetUpdatesCall struct {
 	Call[[]Update]
 }
@@ -330,7 +330,7 @@ func (call *SendMessageCall) ReplyToMessageID(replyToMessageID int) *SendMessage
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendMessageCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendMessageCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -406,6 +406,7 @@ func (call *ForwardMessageCall) MessageID(messageID int) *ForwardMessageCall {
 // CopyMessageCall reprenesents a call to the copyMessage method.
 // Use this method to copy messages of any kind
 // Service messages and invoice messages can't be copied
+// A quiz poll can be copied only if the value of the field correct_option_id is known to the bot
 // The method is analogous to the method forwardMessage, but the copied message doesn't have a link to the original message
 // Returns the MessageId of the sent message on success.
 type CopyMessageCall struct {
@@ -489,7 +490,7 @@ func (call *CopyMessageCall) ReplyToMessageID(replyToMessageID int) *CopyMessage
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *CopyMessageCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *CopyMessageCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -577,7 +578,7 @@ func (call *SendPhotoCall) ReplyToMessageID(replyToMessageID int) *SendPhotoCall
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendPhotoCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendPhotoCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -692,7 +693,7 @@ func (call *SendAudioCall) ReplyToMessageID(replyToMessageID int) *SendAudioCall
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendAudioCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendAudioCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -793,7 +794,7 @@ func (call *SendDocumentCall) ReplyToMessageID(replyToMessageID int) *SendDocume
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendDocumentCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendDocumentCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -888,7 +889,7 @@ func (call *SendVideoCall) CaptionEntities(captionEntities []MessageEntity) *Sen
 	return call
 }
 
-// SupportsStreaming Pass True, if the uploaded video is suitable for streaming
+// SupportsStreaming Pass True if the uploaded video is suitable for streaming
 func (call *SendVideoCall) SupportsStreaming(supportsStreaming bool) *SendVideoCall {
 	call.request.Bool("supports_streaming", supportsStreaming)
 	return call
@@ -912,7 +913,7 @@ func (call *SendVideoCall) ReplyToMessageID(replyToMessageID int) *SendVideoCall
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendVideoCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendVideoCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1025,7 +1026,7 @@ func (call *SendAnimationCall) ReplyToMessageID(replyToMessageID int) *SendAnima
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendAnimationCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendAnimationCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1121,7 +1122,7 @@ func (call *SendVoiceCall) ReplyToMessageID(replyToMessageID int) *SendVoiceCall
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendVoiceCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendVoiceCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1210,7 +1211,7 @@ func (call *SendVideoNoteCall) ReplyToMessageID(replyToMessageID int) *SendVideo
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendVideoNoteCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendVideoNoteCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1281,7 +1282,7 @@ func (call *SendMediaGroupCall) ReplyToMessageID(replyToMessageID int) *SendMedi
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendMediaGroupCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendMediaGroupCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1377,7 +1378,7 @@ func (call *SendLocationCall) ReplyToMessageID(replyToMessageID int) *SendLocati
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendLocationCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendLocationCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1668,7 +1669,7 @@ func (call *SendVenueCall) ReplyToMessageID(replyToMessageID int) *SendVenueCall
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendVenueCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendVenueCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1758,7 +1759,7 @@ func (call *SendContactCall) ReplyToMessageID(replyToMessageID int) *SendContact
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendContactCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendContactCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1872,7 +1873,7 @@ func (call *SendPollCall) CloseDate(closeDate int) *SendPollCall {
 	return call
 }
 
-// IsClosed Pass True, if the poll needs to be immediately closed. This can be useful for poll preview.
+// IsClosed Pass True if the poll needs to be immediately closed. This can be useful for poll preview.
 func (call *SendPollCall) IsClosed(isClosed bool) *SendPollCall {
 	call.request.Bool("is_closed", isClosed)
 	return call
@@ -1896,7 +1897,7 @@ func (call *SendPollCall) ReplyToMessageID(replyToMessageID int) *SendPollCall {
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendPollCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendPollCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -1964,7 +1965,7 @@ func (call *SendDiceCall) ReplyToMessageID(replyToMessageID int) *SendDiceCall {
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendDiceCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendDiceCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -2299,67 +2300,67 @@ func (call *PromoteChatMemberCall) UserID(userID UserID) *PromoteChatMemberCall 
 	return call
 }
 
-// IsAnonymous Pass True, if the administrator's presence in the chat is hidden
+// IsAnonymous Pass True if the administrator's presence in the chat is hidden
 func (call *PromoteChatMemberCall) IsAnonymous(isAnonymous bool) *PromoteChatMemberCall {
 	call.request.Bool("is_anonymous", isAnonymous)
 	return call
 }
 
-// CanManageChat Pass True, if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege
+// CanManageChat Pass True if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege
 func (call *PromoteChatMemberCall) CanManageChat(canManageChat bool) *PromoteChatMemberCall {
 	call.request.Bool("can_manage_chat", canManageChat)
 	return call
 }
 
-// CanPostMessages Pass True, if the administrator can create channel posts, channels only
+// CanPostMessages Pass True if the administrator can create channel posts, channels only
 func (call *PromoteChatMemberCall) CanPostMessages(canPostMessages bool) *PromoteChatMemberCall {
 	call.request.Bool("can_post_messages", canPostMessages)
 	return call
 }
 
-// CanEditMessages Pass True, if the administrator can edit messages of other users and can pin messages, channels only
+// CanEditMessages Pass True if the administrator can edit messages of other users and can pin messages, channels only
 func (call *PromoteChatMemberCall) CanEditMessages(canEditMessages bool) *PromoteChatMemberCall {
 	call.request.Bool("can_edit_messages", canEditMessages)
 	return call
 }
 
-// CanDeleteMessages Pass True, if the administrator can delete messages of other users
+// CanDeleteMessages Pass True if the administrator can delete messages of other users
 func (call *PromoteChatMemberCall) CanDeleteMessages(canDeleteMessages bool) *PromoteChatMemberCall {
 	call.request.Bool("can_delete_messages", canDeleteMessages)
 	return call
 }
 
-// CanManageVideoChats Pass True, if the administrator can manage video chats
+// CanManageVideoChats Pass True if the administrator can manage video chats
 func (call *PromoteChatMemberCall) CanManageVideoChats(canManageVideoChats bool) *PromoteChatMemberCall {
 	call.request.Bool("can_manage_video_chats", canManageVideoChats)
 	return call
 }
 
-// CanRestrictMembers Pass True, if the administrator can restrict, ban or unban chat members
+// CanRestrictMembers Pass True if the administrator can restrict, ban or unban chat members
 func (call *PromoteChatMemberCall) CanRestrictMembers(canRestrictMembers bool) *PromoteChatMemberCall {
 	call.request.Bool("can_restrict_members", canRestrictMembers)
 	return call
 }
 
-// CanPromoteMembers Pass True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)
+// CanPromoteMembers Pass True if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)
 func (call *PromoteChatMemberCall) CanPromoteMembers(canPromoteMembers bool) *PromoteChatMemberCall {
 	call.request.Bool("can_promote_members", canPromoteMembers)
 	return call
 }
 
-// CanChangeInfo Pass True, if the administrator can change chat title, photo and other settings
+// CanChangeInfo Pass True if the administrator can change chat title, photo and other settings
 func (call *PromoteChatMemberCall) CanChangeInfo(canChangeInfo bool) *PromoteChatMemberCall {
 	call.request.Bool("can_change_info", canChangeInfo)
 	return call
 }
 
-// CanInviteUsers Pass True, if the administrator can invite new users to the chat
+// CanInviteUsers Pass True if the administrator can invite new users to the chat
 func (call *PromoteChatMemberCall) CanInviteUsers(canInviteUsers bool) *PromoteChatMemberCall {
 	call.request.Bool("can_invite_users", canInviteUsers)
 	return call
 }
 
-// CanPinMessages Pass True, if the administrator can pin messages, supergroups only
+// CanPinMessages Pass True if the administrator can pin messages, supergroups only
 func (call *PromoteChatMemberCall) CanPinMessages(canPinMessages bool) *PromoteChatMemberCall {
 	call.request.Bool("can_pin_messages", canPinMessages)
 	return call
@@ -3004,7 +3005,7 @@ func (call *PinChatMessageCall) MessageID(messageID int) *PinChatMessageCall {
 	return call
 }
 
-// DisableNotification Pass True, if it is not necessary to send a notification to all chat members about the new pinned message. Notifications are always disabled in channels and private chats.
+// DisableNotification Pass True if it is not necessary to send a notification to all chat members about the new pinned message. Notifications are always disabled in channels and private chats.
 func (call *PinChatMessageCall) DisableNotification(disableNotification bool) *PinChatMessageCall {
 	call.request.Bool("disable_notification", disableNotification)
 	return call
@@ -3144,9 +3145,8 @@ func (call *GetChatCall) ChatID(chatID PeerID) *GetChatCall {
 }
 
 // GetChatAdministratorsCall reprenesents a call to the getChatAdministrators method.
-// Use this method to get a list of administrators in a chat
-// On success, returns an Array of ChatMember objects that contains information about all chat administrators except other bots
-// If the chat is a group or a supergroup and no administrators were appointed, only the creator will be returned.
+// Use this method to get a list of administrators in a chat, which aren't bots
+// Returns an Array of ChatMember objects.
 type GetChatAdministratorsCall struct {
 	Call[[]ChatMember]
 }
@@ -3464,7 +3464,7 @@ func (call *DeleteMyCommandsCall) LanguageCode(languageCode string) *DeleteMyCom
 
 // GetMyCommandsCall reprenesents a call to the getMyCommands method.
 // Use this method to get the current list of the bot's commands for the given scope and user language
-// Returns Array of BotCommand on success
+// Returns an Array of BotCommand objects
 // If commands aren't set, an empty list is returned.
 type GetMyCommandsCall struct {
 	Call[[]BotCommand]
@@ -4093,7 +4093,7 @@ func (call *SendStickerCall) ReplyToMessageID(replyToMessageID int) *SendSticker
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendStickerCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendStickerCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -4134,6 +4134,38 @@ func (client *Client) GetStickerSet(name string) *GetStickerSetCall {
 // Name Name of the sticker set
 func (call *GetStickerSetCall) Name(name string) *GetStickerSetCall {
 	call.request.String("name", name)
+	return call
+}
+
+// GetCustomEmojiStickersCall reprenesents a call to the getCustomEmojiStickers method.
+// Use this method to get information about custom emoji stickers by their identifiers
+// Returns an Array of Sticker objects.
+type GetCustomEmojiStickersCall struct {
+	Call[[]Sticker]
+}
+
+// NewGetCustomEmojiStickersCall constructs a new GetCustomEmojiStickersCall with required parameters.
+// customEmojiIds - List of custom emoji identifiers. At most 200 custom emoji identifiers can be specified.
+func NewGetCustomEmojiStickersCall(customEmojiIds []string) *GetCustomEmojiStickersCall {
+	return &GetCustomEmojiStickersCall{
+		Call[[]Sticker]{
+			request: NewRequest("getCustomEmojiStickers").
+				JSON("custom_emoji_ids", customEmojiIds),
+		},
+	}
+}
+
+// GetCustomEmojiStickersCall constructs a new GetCustomEmojiStickersCall with required parameters.
+func (client *Client) GetCustomEmojiStickers(customEmojiIds []string) *GetCustomEmojiStickersCall {
+	return BindClient(
+		NewGetCustomEmojiStickersCall(customEmojiIds),
+		client,
+	)
+}
+
+// CustomEmojiIds List of custom emoji identifiers. At most 200 custom emoji identifiers can be specified.
+func (call *GetCustomEmojiStickersCall) CustomEmojiIds(customEmojiIds []string) *GetCustomEmojiStickersCall {
+	call.request.JSON("custom_emoji_ids", customEmojiIds)
 	return call
 }
 
@@ -4246,15 +4278,15 @@ func (call *CreateNewStickerSetCall) WEBMSticker(webmSticker InputFile) *CreateN
 	return call
 }
 
-// Emojis One or more emoji corresponding to the sticker
-func (call *CreateNewStickerSetCall) Emojis(emojis string) *CreateNewStickerSetCall {
-	call.request.String("emojis", emojis)
+// StickerType Type of stickers in the set, pass “regular” or “mask”. Custom emoji sticker sets can't be created via the Bot API at the moment. By default, a regular sticker set is created.
+func (call *CreateNewStickerSetCall) StickerType(stickerType string) *CreateNewStickerSetCall {
+	call.request.String("sticker_type", stickerType)
 	return call
 }
 
-// ContainsMasks Pass True, if a set of mask stickers should be created
-func (call *CreateNewStickerSetCall) ContainsMasks(containsMasks bool) *CreateNewStickerSetCall {
-	call.request.Bool("contains_masks", containsMasks)
+// Emojis One or more emoji corresponding to the sticker
+func (call *CreateNewStickerSetCall) Emojis(emojis string) *CreateNewStickerSetCall {
+	call.request.String("emojis", emojis)
 	return call
 }
 
@@ -4502,7 +4534,7 @@ func (call *AnswerInlineQueryCall) CacheTime(cacheTime int) *AnswerInlineQueryCa
 	return call
 }
 
-// IsPersonal Pass True, if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query
+// IsPersonal Pass True if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query
 func (call *AnswerInlineQueryCall) IsPersonal(isPersonal bool) *AnswerInlineQueryCall {
 	call.request.Bool("is_personal", isPersonal)
 	return call
@@ -4694,43 +4726,43 @@ func (call *SendInvoiceCall) PhotoHeight(photoHeight int) *SendInvoiceCall {
 	return call
 }
 
-// NeedName Pass True, if you require the user's full name to complete the order
+// NeedName Pass True if you require the user's full name to complete the order
 func (call *SendInvoiceCall) NeedName(needName bool) *SendInvoiceCall {
 	call.request.Bool("need_name", needName)
 	return call
 }
 
-// NeedPhoneNumber Pass True, if you require the user's phone number to complete the order
+// NeedPhoneNumber Pass True if you require the user's phone number to complete the order
 func (call *SendInvoiceCall) NeedPhoneNumber(needPhoneNumber bool) *SendInvoiceCall {
 	call.request.Bool("need_phone_number", needPhoneNumber)
 	return call
 }
 
-// NeedEmail Pass True, if you require the user's email address to complete the order
+// NeedEmail Pass True if you require the user's email address to complete the order
 func (call *SendInvoiceCall) NeedEmail(needEmail bool) *SendInvoiceCall {
 	call.request.Bool("need_email", needEmail)
 	return call
 }
 
-// NeedShippingAddress Pass True, if you require the user's shipping address to complete the order
+// NeedShippingAddress Pass True if you require the user's shipping address to complete the order
 func (call *SendInvoiceCall) NeedShippingAddress(needShippingAddress bool) *SendInvoiceCall {
 	call.request.Bool("need_shipping_address", needShippingAddress)
 	return call
 }
 
-// SendPhoneNumberToProvider Pass True, if the user's phone number should be sent to provider
+// SendPhoneNumberToProvider Pass True if the user's phone number should be sent to provider
 func (call *SendInvoiceCall) SendPhoneNumberToProvider(sendPhoneNumberToProvider bool) *SendInvoiceCall {
 	call.request.Bool("send_phone_number_to_provider", sendPhoneNumberToProvider)
 	return call
 }
 
-// SendEmailToProvider Pass True, if the user's email address should be sent to provider
+// SendEmailToProvider Pass True if the user's email address should be sent to provider
 func (call *SendInvoiceCall) SendEmailToProvider(sendEmailToProvider bool) *SendInvoiceCall {
 	call.request.Bool("send_email_to_provider", sendEmailToProvider)
 	return call
 }
 
-// IsFlexible Pass True, if the final price depends on the shipping method
+// IsFlexible Pass True if the final price depends on the shipping method
 func (call *SendInvoiceCall) IsFlexible(isFlexible bool) *SendInvoiceCall {
 	call.request.Bool("is_flexible", isFlexible)
 	return call
@@ -4754,7 +4786,7 @@ func (call *SendInvoiceCall) ReplyToMessageID(replyToMessageID int) *SendInvoice
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendInvoiceCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendInvoiceCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -4880,43 +4912,43 @@ func (call *CreateInvoiceLinkCall) PhotoHeight(photoHeight int) *CreateInvoiceLi
 	return call
 }
 
-// NeedName Pass True, if you require the user's full name to complete the order
+// NeedName Pass True if you require the user's full name to complete the order
 func (call *CreateInvoiceLinkCall) NeedName(needName bool) *CreateInvoiceLinkCall {
 	call.request.Bool("need_name", needName)
 	return call
 }
 
-// NeedPhoneNumber Pass True, if you require the user's phone number to complete the order
+// NeedPhoneNumber Pass True if you require the user's phone number to complete the order
 func (call *CreateInvoiceLinkCall) NeedPhoneNumber(needPhoneNumber bool) *CreateInvoiceLinkCall {
 	call.request.Bool("need_phone_number", needPhoneNumber)
 	return call
 }
 
-// NeedEmail Pass True, if you require the user's email address to complete the order
+// NeedEmail Pass True if you require the user's email address to complete the order
 func (call *CreateInvoiceLinkCall) NeedEmail(needEmail bool) *CreateInvoiceLinkCall {
 	call.request.Bool("need_email", needEmail)
 	return call
 }
 
-// NeedShippingAddress Pass True, if you require the user's shipping address to complete the order
+// NeedShippingAddress Pass True if you require the user's shipping address to complete the order
 func (call *CreateInvoiceLinkCall) NeedShippingAddress(needShippingAddress bool) *CreateInvoiceLinkCall {
 	call.request.Bool("need_shipping_address", needShippingAddress)
 	return call
 }
 
-// SendPhoneNumberToProvider Pass True, if the user's phone number should be sent to the provider
+// SendPhoneNumberToProvider Pass True if the user's phone number should be sent to the provider
 func (call *CreateInvoiceLinkCall) SendPhoneNumberToProvider(sendPhoneNumberToProvider bool) *CreateInvoiceLinkCall {
 	call.request.Bool("send_phone_number_to_provider", sendPhoneNumberToProvider)
 	return call
 }
 
-// SendEmailToProvider Pass True, if the user's email address should be sent to the provider
+// SendEmailToProvider Pass True if the user's email address should be sent to the provider
 func (call *CreateInvoiceLinkCall) SendEmailToProvider(sendEmailToProvider bool) *CreateInvoiceLinkCall {
 	call.request.Bool("send_email_to_provider", sendEmailToProvider)
 	return call
 }
 
-// IsFlexible Pass True, if the final price depends on the shipping method
+// IsFlexible Pass True if the final price depends on the shipping method
 func (call *CreateInvoiceLinkCall) IsFlexible(isFlexible bool) *CreateInvoiceLinkCall {
 	call.request.Bool("is_flexible", isFlexible)
 	return call
@@ -4932,7 +4964,7 @@ type AnswerShippingQueryCall struct {
 
 // NewAnswerShippingQueryCall constructs a new AnswerShippingQueryCall with required parameters.
 // shippingQueryID - Unique identifier for the query to be answered
-// ok - Specify True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible)
+// ok - Pass True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible)
 func NewAnswerShippingQueryCall(shippingQueryID string, ok bool) *AnswerShippingQueryCall {
 	return &AnswerShippingQueryCall{
 		CallNoResult{
@@ -4957,7 +4989,7 @@ func (call *AnswerShippingQueryCall) ShippingQueryID(shippingQueryID string) *An
 	return call
 }
 
-// Ok Specify True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible)
+// Ok Pass True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible)
 func (call *AnswerShippingQueryCall) Ok(ok bool) *AnswerShippingQueryCall {
 	call.request.Bool("ok", ok)
 	return call
@@ -5124,7 +5156,7 @@ func (call *SendGameCall) ReplyToMessageID(replyToMessageID int) *SendGameCall {
 	return call
 }
 
-// AllowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to message is not found
+// AllowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
 func (call *SendGameCall) AllowSendingWithoutReply(allowSendingWithoutReply bool) *SendGameCall {
 	call.request.Bool("allow_sending_without_reply", allowSendingWithoutReply)
 	return call
@@ -5177,13 +5209,13 @@ func (call *SetGameScoreCall) Score(score int) *SetGameScoreCall {
 	return call
 }
 
-// Force Pass True, if the high score is allowed to decrease. This can be useful when fixing mistakes or banning cheaters
+// Force Pass True if the high score is allowed to decrease. This can be useful when fixing mistakes or banning cheaters
 func (call *SetGameScoreCall) Force(force bool) *SetGameScoreCall {
 	call.request.Bool("force", force)
 	return call
 }
 
-// DisableEditMessage Pass True, if the game message should not be automatically edited to include the current scoreboard
+// DisableEditMessage Pass True if the game message should not be automatically edited to include the current scoreboard
 func (call *SetGameScoreCall) DisableEditMessage(disableEditMessage bool) *SetGameScoreCall {
 	call.request.Bool("disable_edit_message", disableEditMessage)
 	return call
@@ -5210,19 +5242,19 @@ func (call *SetGameScoreCall) InlineMessageID(inlineMessageID string) *SetGameSc
 // GetGameHighScoresCall reprenesents a call to the getGameHighScores method.
 // Use this method to get data for high score tables
 // Will return the score of the specified user and several of their neighbors in a game
-// On success, returns an Array of GameHighScore objects.
+// Returns an Array of GameHighScore objects.
 // This method will currently return scores for the target user, plus two of their closest neighbors on each side
 // Will also return the top three users if the user and their neighbors are not among them
 // Please note that this behavior is subject to change.
 type GetGameHighScoresCall struct {
-	Call[GameHighScore]
+	Call[[]GameHighScore]
 }
 
 // NewGetGameHighScoresCall constructs a new GetGameHighScoresCall with required parameters.
 // userID - Target user id
 func NewGetGameHighScoresCall(userID UserID) *GetGameHighScoresCall {
 	return &GetGameHighScoresCall{
-		Call[GameHighScore]{
+		Call[[]GameHighScore]{
 			request: NewRequest("getGameHighScores").
 				UserID("user_id", userID),
 		},

--- a/methods_gen.go
+++ b/methods_gen.go
@@ -4279,8 +4279,8 @@ func (call *CreateNewStickerSetCall) WEBMSticker(webmSticker InputFile) *CreateN
 }
 
 // StickerType Type of stickers in the set, pass “regular” or “mask”. Custom emoji sticker sets can't be created via the Bot API at the moment. By default, a regular sticker set is created.
-func (call *CreateNewStickerSetCall) StickerType(stickerType string) *CreateNewStickerSetCall {
-	call.request.String("sticker_type", stickerType)
+func (call *CreateNewStickerSetCall) StickerType(stickerType StickerType) *CreateNewStickerSetCall {
+	call.request.Stringer("sticker_type", stickerType)
 	return call
 }
 

--- a/types_gen.go
+++ b/types_gen.go
@@ -150,6 +150,9 @@ type Chat struct {
 	// Optional. True, if privacy settings of the other party in the private chat allows to use tg://user?id=<user_id> links only in chats with the user. Returned only in getChat.
 	HasPrivateForwards bool `json:"has_private_forwards,omitempty"`
 
+	// Optional. True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat. Returned only in getChat.
+	HasRestrictedVoiceAndVideoMessages bool `json:"has_restricted_voice_and_video_messages,omitempty"`
+
 	// Optional. True, if users need to join the supergroup before they can send messages. Returned only in getChat.
 	JoinToSendMessages bool `json:"join_to_send_messages,omitempty"`
 
@@ -378,7 +381,7 @@ type MessageID struct {
 
 // MessageEntity this object represents one special entity in a text message. For example, hashtags, usernames, URLs, etc.
 type MessageEntity struct {
-	// Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames)
+	// Type of the entity. Currently, can be “mention” (@username), “hashtag” (#hashtag), “cashtag” ($USD), “bot_command” (/start@jobs_bot), “url” (https://telegram.org), “email” (do-not-reply@telegram.org), “phone_number” (+1-212-555-0123), “bold” (bold text), “italic” (italic text), “underline” (underlined text), “strikethrough” (strikethrough text), “spoiler” (spoiler message), “code” (monowidth string), “pre” (monowidth block), “text_link” (for clickable text URLs), “text_mention” (for users without usernames), “custom_emoji” (for inline custom emoji stickers)
 	Type MessageEntityType `json:"type"`
 
 	// Offset in UTF-16 code units to the start of the entity
@@ -395,6 +398,9 @@ type MessageEntity struct {
 
 	// Optional. For “pre” only, the programming language of the entity text
 	Language string `json:"language,omitempty"`
+
+	// Optional. For “custom_emoji” only, unique identifier of the custom emoji. Use getCustomEmojiStickers to get full information about the sticker
+	CustomEmojiID string `json:"custom_emoji_id,omitempty"`
 }
 
 // PhotoSize this object represents one size of a photo or a file / sticker thumbnail.
@@ -1365,7 +1371,7 @@ type InputMediaVideo struct {
 	// Optional. Video duration in seconds
 	Duration int `json:"duration,omitempty"`
 
-	// Optional. Pass True, if the uploaded video is suitable for streaming
+	// Optional. Pass True if the uploaded video is suitable for streaming
 	SupportsStreaming bool `json:"supports_streaming,omitempty"`
 }
 
@@ -1461,6 +1467,9 @@ type Sticker struct {
 	// Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
 	FileUniqueID string `json:"file_unique_id"`
 
+	// Type of the sticker, currently one of “regular”, “mask”, “custom_emoji”. The type of the sticker is independent from its format, which is determined by the fields is_animated and is_video.
+	Type string `json:"type"`
+
 	// Sticker width
 	Width int `json:"width"`
 
@@ -1482,11 +1491,14 @@ type Sticker struct {
 	// Optional. Name of the sticker set to which the sticker belongs
 	SetName string `json:"set_name,omitempty"`
 
-	// Optional. Premium animation for the sticker, if the sticker is premium
+	// Optional. For premium regular stickers, premium animation for the sticker
 	PremiumAnimation *File `json:"premium_animation,omitempty"`
 
 	// Optional. For mask stickers, the position where the mask should be placed
 	MaskPosition *MaskPosition `json:"mask_position,omitempty"`
+
+	// Optional. For custom emoji stickers, unique identifier of the custom emoji
+	CustomEmojiID string `json:"custom_emoji_id,omitempty"`
 
 	// Optional. File size in bytes
 	FileSize int `json:"file_size,omitempty"`
@@ -1500,14 +1512,14 @@ type StickerSet struct {
 	// Sticker set title
 	Title string `json:"title"`
 
+	// Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”
+	StickerType string `json:"sticker_type"`
+
 	// True, if the sticker set contains animated stickers
 	IsAnimated bool `json:"is_animated"`
 
 	// True, if the sticker set contains video stickers
 	IsVideo bool `json:"is_video"`
-
-	// True, if the sticker set contains masks
-	ContainsMasks bool `json:"contains_masks"`
 
 	// List of all set stickers
 	Stickers []Sticker `json:"stickers"`
@@ -1572,7 +1584,7 @@ type InlineQueryResultArticle struct {
 	// Optional. URL of the result
 	URL string `json:"url,omitempty"`
 
-	// Optional. Pass True, if you don't want the URL to be shown in the message
+	// Optional. Pass True if you don't want the URL to be shown in the message
 	HideURL bool `json:"hide_url,omitempty"`
 
 	// Optional. Short description of the result
@@ -2379,25 +2391,25 @@ type InputInvoiceMessageContent struct {
 	// Optional. Photo height
 	PhotoHeight int `json:"photo_height,omitempty"`
 
-	// Optional. Pass True, if you require the user's full name to complete the order
+	// Optional. Pass True if you require the user's full name to complete the order
 	NeedName bool `json:"need_name,omitempty"`
 
-	// Optional. Pass True, if you require the user's phone number to complete the order
+	// Optional. Pass True if you require the user's phone number to complete the order
 	NeedPhoneNumber bool `json:"need_phone_number,omitempty"`
 
-	// Optional. Pass True, if you require the user's email address to complete the order
+	// Optional. Pass True if you require the user's email address to complete the order
 	NeedEmail bool `json:"need_email,omitempty"`
 
-	// Optional. Pass True, if you require the user's shipping address to complete the order
+	// Optional. Pass True if you require the user's shipping address to complete the order
 	NeedShippingAddress bool `json:"need_shipping_address,omitempty"`
 
-	// Optional. Pass True, if the user's phone number should be sent to provider
+	// Optional. Pass True if the user's phone number should be sent to provider
 	SendPhoneNumberToProvider bool `json:"send_phone_number_to_provider,omitempty"`
 
-	// Optional. Pass True, if the user's email address should be sent to provider
+	// Optional. Pass True if the user's email address should be sent to provider
 	SendEmailToProvider bool `json:"send_email_to_provider,omitempty"`
 
-	// Optional. Pass True, if the final price depends on the shipping method
+	// Optional. Pass True if the final price depends on the shipping method
 	IsFlexible bool `json:"is_flexible,omitempty"`
 }
 
@@ -2869,6 +2881,9 @@ type WebAppUser struct {
 
 	// Optional. IETF language tag of the user's language. Returns in user field only.
 	LanguageCode string `json:"language_code,omitempty"`
+
+	// Optional. True, if this user is a Telegram Premium user
+	IsPremium bool `json:"is_premium,omitempty"`
 
 	// Optional. URL of the user’s profile photo. The photo can be in .jpeg or .svg formats. Only returned for Web Apps launched from the attachment menu.
 	PhotoURL string `json:"photo_url,omitempty"`

--- a/types_gen.go
+++ b/types_gen.go
@@ -1468,7 +1468,7 @@ type Sticker struct {
 	FileUniqueID string `json:"file_unique_id"`
 
 	// Type of the sticker, currently one of “regular”, “mask”, “custom_emoji”. The type of the sticker is independent from its format, which is determined by the fields is_animated and is_video.
-	Type string `json:"type"`
+	Type StickerType `json:"type"`
 
 	// Sticker width
 	Width int `json:"width"`
@@ -1513,7 +1513,7 @@ type StickerSet struct {
 	Title string `json:"title"`
 
 	// Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”
-	StickerType string `json:"sticker_type"`
+	StickerType StickerType `json:"sticker_type"`
 
 	// True, if the sticker set contains animated stickers
 	IsAnimated bool `json:"is_animated"`

--- a/types_gen_ext.go
+++ b/types_gen_ext.go
@@ -215,10 +215,10 @@ type CallbackGame struct{}
 // ReplyMarkup generic for keyboards.
 //
 // Known implementations:
-//  - [ReplyKeyboardMarkup]
-//  - [InlineKeyboardMarkup]
-//  - [ReplyKeyboardRemove]
-//  - [ForceReply]
+//   - [ReplyKeyboardMarkup]
+//   - [InlineKeyboardMarkup]
+//   - [ReplyKeyboardRemove]
+//   - [ForceReply]
 type ReplyMarkup interface {
 	isReplyMarkup()
 }
@@ -271,7 +271,9 @@ func NewInlineKeyboardButtonLoginURL(text string, loginURL LoginURL) InlineKeybo
 }
 
 // NewInlineKeyboardButtonSwitchInlineQuery represents button that
-//  will prompt the user to select one of their chats,
+//
+//	will prompt the user to select one of their chats,
+//
 // open that chat and insert the bot's username and the specified inline query in the input field.
 func NewInlineKeyboardButtonSwitchInlineQuery(text string, query string) InlineKeyboardButton {
 	return InlineKeyboardButton{
@@ -692,11 +694,11 @@ func (result InlineQueryResultVenue) MarshalJSON() ([]byte, error) {
 // InputMessageContent it's generic interface for all types of input message content.
 //
 // Known implementations:
-//  - [InputTextMessageContent]
-//  - [InputLocationMessageContent]
-//  - [InputVenueMessageContent]
-//  - [InputContactMessageContent]
-//  - [InputInvoiceMessageContent]
+//   - [InputTextMessageContent]
+//   - [InputLocationMessageContent]
+//   - [InputVenueMessageContent]
+//   - [InputContactMessageContent]
+//   - [InputInvoiceMessageContent]
 type InputMessageContent interface {
 	isInputMessageContent()
 }
@@ -1187,6 +1189,9 @@ const (
 
 	// for users without usernames
 	MessageEntityTypeTextMention
+
+	// for inline custom emoji sticker
+	MessageEntityCustomEmoji
 )
 
 // String returns string representation of MessageEntityType.
@@ -1209,6 +1214,7 @@ func (met MessageEntityType) String() string {
 			"pre",
 			"text_link",
 			"text_mention",
+			"custom_emoji",
 		}[met-1]
 	}
 
@@ -1259,6 +1265,8 @@ func (met *MessageEntityType) UnmarshalText(v []byte) error {
 		*met = MessageEntityTypeTextLink
 	case "text_mention":
 		*met = MessageEntityTypeTextMention
+	case "custom_emoji":
+		*met = MessageEntityCustomEmoji
 	default:
 		return fmt.Errorf("unknown message entity type")
 	}
@@ -1269,4 +1277,46 @@ func (met *MessageEntityType) UnmarshalText(v []byte) error {
 // Extract entitie value from plain text.
 func (me MessageEntity) Extract(text string) string {
 	return string([]rune(text)[me.Offset : me.Offset+me.Length])
+}
+
+// StickerType it's type for describe content of Sticker.
+type StickerType int
+
+const (
+	StickerTypeUnknown StickerType = iota
+	StickerTypeRegular
+	StickerTypeMask
+	StickerTypeCustomEmoji
+)
+
+func (sticker StickerType) String() string {
+	switch sticker {
+	case StickerTypeRegular:
+		return "regular"
+	case StickerTypeMask:
+		return "mask"
+	case StickerTypeCustomEmoji:
+		return "custom_emoji"
+	default:
+		return "unknown"
+	}
+}
+
+func (sticker StickerType) MarshalText() ([]byte, error) {
+	return []byte(sticker.String()), nil
+}
+
+func (sticker *StickerType) UnmarshalText(v []byte) error {
+	switch string(v) {
+	case "regular":
+		*sticker = StickerTypeRegular
+	case "mask":
+		*sticker = StickerTypeMask
+	case "custom_emoji":
+		*sticker = StickerTypeCustomEmoji
+	default:
+		*sticker = StickerTypeUnknown
+	}
+
+	return nil
 }

--- a/types_gen_ext.go
+++ b/types_gen_ext.go
@@ -1196,7 +1196,7 @@ const (
 
 // String returns string representation of MessageEntityType.
 func (met MessageEntityType) String() string {
-	if met > MessageEntityTypeUnknown && met <= MessageEntityTypeTextMention {
+	if met > MessageEntityTypeUnknown && met <= MessageEntityCustomEmoji {
 		return [...]string{
 			"mention",
 			"hashtag",

--- a/types_gen_ext_test.go
+++ b/types_gen_ext_test.go
@@ -987,6 +987,7 @@ func TestMessageEntityType_UnmarshalText(t *testing.T) {
 		{"pre", MessageEntityTypePre, false},
 		{"text_link", MessageEntityTypeTextLink, false},
 		{"text_mention", MessageEntityTypeTextMention, false},
+		{"custom_emoji", MessageEntityCustomEmoji, false},
 	} {
 		var e MessageEntityType
 

--- a/types_gen_ext_test.go
+++ b/types_gen_ext_test.go
@@ -923,6 +923,7 @@ func TestMessageEntityType_String(t *testing.T) {
 		{MessageEntityTypePre, "pre"},
 		{MessageEntityTypeTextLink, "text_link"},
 		{MessageEntityTypeTextMention, "text_mention"},
+		{MessageEntityCustomEmoji, "custom_emoji"},
 	} {
 		assert.Equal(t, test.Want, test.Type.String())
 	}
@@ -951,6 +952,7 @@ func TestMessageEntityType_MarshalText(t *testing.T) {
 		{MessageEntityTypePre, []byte("pre"), false},
 		{MessageEntityTypeTextLink, []byte("text_link"), false},
 		{MessageEntityTypeTextMention, []byte("text_mention"), false},
+		{MessageEntityCustomEmoji, []byte("custom_emoji"), false},
 	} {
 		b, err := test.Type.MarshalText()
 		if test.Err {
@@ -1053,5 +1055,39 @@ func TestUpdate_Chat(t *testing.T) {
 		{&Update{ChatJoinRequest: &ChatJoinRequest{Chat: chat}}, &chat},
 	} {
 		assert.Equal(t, test.Chat, test.Update.Chat())
+	}
+}
+
+func TestStickerType_MarshalText(t *testing.T) {
+	for _, test := range []struct {
+		Type StickerType
+		Want string
+	}{
+		{StickerTypeUnknown, "unknown"},
+		{StickerTypeRegular, "regular"},
+		{StickerTypeMask, "mask"},
+		{StickerTypeCustomEmoji, "custom_emoji"},
+	} {
+		b, err := test.Type.MarshalText()
+		assert.NoError(t, err)
+		assert.Equal(t, test.Want, string(b))
+	}
+}
+
+func TestStickerType_UnmarshalText(t *testing.T) {
+	for _, test := range []struct {
+		Input string
+		Want  StickerType
+	}{
+		{"unknown", StickerTypeUnknown},
+		{"regular", StickerTypeRegular},
+		{"mask", StickerTypeMask},
+		{"custom_emoji", StickerTypeCustomEmoji},
+	} {
+		var e StickerType
+
+		err := e.UnmarshalText([]byte(test.Input))
+		assert.NoError(t, err)
+		assert.Equal(t, test.Want, e)
 	}
 }


### PR DESCRIPTION
- [x] Added the [MessageEntity](https://core.telegram.org/bots/api#messageentity) type “custom_emoji”.
- [x] Added the field custom_emoji_id to the class [MessageEntity](https://core.telegram.org/bots/api#messageentity) for “custom_emoji” entities.
- [x] Added the method [getCustomEmojiStickers](https://core.telegram.org/bots/api#getcustomemojistickers).
- [x] Added the fields type and custom_emoji_id to the class [Sticker](https://core.telegram.org/bots/api#sticker).
- [x] Added the field sticker_type to the class [StickerSet](https://core.telegram.org/bots/api#stickerset), describing the type of stickers in the set.
- [x] The field contains_masks has been removed from the documentation of the class [StickerSet](https://core.telegram.org/bots/api#stickerset). The field is still returned in the object for backward compatibility, but new bots should use the field sticker_type instead.
- [x] Added the parameter sticker_type to the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset).
- [x] The parameter contains_masks has been removed from the documentation of the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset). The parameter will still work for backward compatibility, but new bots should use the parameter sticker_type instead.