### PR TITLE
feat(tg): accept any http client what satisfies doer interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 )
 
-type doer interface {
+type Doer interface {
 	Do(r *http.Request) (*http.Response, error)
 }
 
@@ -30,7 +30,7 @@ type Client struct {
 
 	// http client,
 	// default values is http.DefaultClient
-	doer doer
+	doer Doer
 
 	// contains cached bot info
 	me     *User
@@ -48,7 +48,7 @@ func WithClientServerURL(server string) ClientOption {
 }
 
 // WithClientDoer sets custom http client for Client.
-func WithClientDoer(doer doer) ClientOption {
+func WithClientDoer(doer Doer) ClientOption {
 	return func(c *Client) {
 		c.doer = doer
 	}

--- a/client.go
+++ b/client.go
@@ -48,7 +48,7 @@ func WithClientServerURL(server string) ClientOption {
 }
 
 // WithClientDoer sets custom http client for Client.
-func WithClientDoer(doer *http.Client) ClientOption {
+func WithClientDoer(doer doer) ClientOption {
 	return func(c *Client) {
 		c.doer = doer
 	}


### PR DESCRIPTION
This will makes possible usage of [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp), and any http client which relies on some internal things  and have different from http.Client struct return, but satisfies http interface