### PR TITLE
allow to use custom func for get ip from request

### DIFF
--- a/tgb/webhook.go
+++ b/tgb/webhook.go
@@ -33,6 +33,8 @@ type Webhook struct {
 	securitySubnets []netip.Prefix
 	securityToken   string
 
+	ipFromRequestFunc func(r *http.Request) string
+
 	isSetup bool
 }
 
@@ -63,6 +65,14 @@ func WithDropPendingUpdates(dropPendingUpdates bool) WebhookOption {
 func WithWebhookIP(ip string) WebhookOption {
 	return func(webhook *Webhook) {
 		webhook.ip = ip
+	}
+}
+
+// WithWebhookRequestIP sets function to get the IP address from the request.
+// By default the IP address is resolved through the X-Real-Ip and X-Forwarded-For headers.
+func WithWebhookRequestIP(ip func(r *http.Request) string) WebhookOption {
+	return func(webhook *Webhook) {
+		webhook.ipFromRequestFunc = ip
 	}
 }
 
@@ -117,6 +127,8 @@ func NewWebhook(handler Handler, client *tg.Client, url string, options ...Webho
 		allowedUpdates:  []tg.UpdateType{},
 		securitySubnets: defaultSubnets,
 		securityToken:   token,
+
+		ipFromRequestFunc: realip.FromRequest,
 	}
 
 	for _, option := range options {
@@ -322,7 +334,7 @@ func (webhook *Webhook) ServeRequest(ctx context.Context, r *WebhookRequest) *We
 // ServeHTTP is the HTTP handler for webhook requests.
 // Implementation of http.Handler.
 func (webhook *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ip, err := netip.ParseAddr(realip.FromRequest(r))
+	ip, err := netip.ParseAddr(webhook.ipFromRequestFunc(r))
 	if err != nil {
 		webhook.log("failed to parse ip: %s", err)
 		http.Error(w, "failed to parse ip", http.StatusBadRequest)

--- a/tgb/webhook.go
+++ b/tgb/webhook.go
@@ -68,6 +68,10 @@ func WithWebhookIP(ip string) WebhookOption {
 	}
 }
 
+// DefaultWebhookRequestIP is the default function to get the IP address from the request.
+// By default the IP address is resolved through the X-Real-Ip and X-Forwarded-For headers.
+var DefaultWebhookRequestIP = realip.FromRequest
+
 // WithWebhookRequestIP sets function to get the IP address from the request.
 // By default the IP address is resolved through the X-Real-Ip and X-Forwarded-For headers.
 func WithWebhookRequestIP(ip func(r *http.Request) string) WebhookOption {
@@ -128,7 +132,7 @@ func NewWebhook(handler Handler, client *tg.Client, url string, options ...Webho
 		securitySubnets: defaultSubnets,
 		securityToken:   token,
 
-		ipFromRequestFunc: realip.FromRequest,
+		ipFromRequestFunc: DefaultWebhookRequestIP,
 	}
 
 	for _, option := range options {

--- a/tgb/webhook_test.go
+++ b/tgb/webhook_test.go
@@ -6,13 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/mr-linch/go-tg"
-	"github.com/mr-linch/go-tg/tgb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -28,27 +28,21 @@ func TestNewWebhook(t *testing.T) {
 		assert.Equal(t, "https://example.com/webhook", webhook.url)
 		assert.NotNil(t, webhook.handler)
 		assert.NotNil(t, webhook.ipFromRequestFunc)
+
 		assert.NotNil(t, webhook.securityToken)
 		assert.Len(t, webhook.securitySubnets, 2)
 	})
 	t.Run("Custom", func(t *testing.T) {
-		var (
-			handler tgb.Handler
-			client  *tg.Client
-		)
-
 		webhook := NewWebhook(
-			handler,
-			client,
+			HandlerFunc(func(ctx context.Context, update *Update) error { return nil }),
+			&tg.Client{},
 			"https://example.com/webhook",
+			WithWebhookIP("1.1.1.1"),
+			WithWebhookSecuritySubnets(netip.MustParsePrefix("1.1.1.1/24")),
+			WithWebhookSecurityToken("12345"),
+			WithWebhookMaxConnections(10),
 			WithWebhookRequestIP(func(r *http.Request) string {
-				ip := r.Header.Get("Cf-Connecting-Ip")
-
-				if ip != "" {
-					return ip
-				}
-
-				return tgb.DefaultWebhookRequestIP(r)
+				return ""
 			}),
 		)
 

--- a/tgb/webhook_test.go
+++ b/tgb/webhook_test.go
@@ -27,6 +27,7 @@ func TestNewWebhook(t *testing.T) {
 
 		assert.Equal(t, "https://example.com/webhook", webhook.url)
 		assert.NotNil(t, webhook.handler)
+		assert.NotNil(t, webhook.ipFromRequestFunc)
 		assert.NotNil(t, webhook.securityToken)
 		assert.Len(t, webhook.securitySubnets, 2)
 	})
@@ -39,10 +40,14 @@ func TestNewWebhook(t *testing.T) {
 			WithWebhookSecuritySubnets(netip.MustParsePrefix("1.1.1.1/24")),
 			WithWebhookSecurityToken("12345"),
 			WithWebhookMaxConnections(10),
+			WithWebhookRequestIP(func(r *http.Request) string {
+				return ""
+			}),
 		)
 
 		assert.Equal(t, "https://example.com/webhook", webhook.url)
 		assert.NotNil(t, webhook.handler)
+		assert.NotNil(t, webhook.ipFromRequestFunc)
 		assert.Equal(t, "12345", webhook.securityToken)
 		assert.Len(t, webhook.securitySubnets, 1)
 		assert.Equal(t, 10, webhook.maxConnections)


### PR DESCRIPTION
Allow to modify default behavior of IP extraction from `http.Request`.

e.g. using use [`Cf-Connection-Ip`](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip)


```go
webhook := tgb.NewWebhook(
	handler,
	client,
	"https://example.com/webhook",
	tgb.WithWebhookRequestIP(func(r *http.Request) string {
		ip := r.Header.Get("Cf-Connecting-Ip")

		if ip != "" {
			return ip
		}

		return tgb.DefaultWebhookRequestIP(r)
	}),
)
```