### PR TITLE
Add blockquote support for HTML and MD2

### DIFF
--- a/parse_mode.go
+++ b/parse_mode.go
@@ -45,6 +45,9 @@ type ParseMode interface {
 	// Preformated text
 	Pre(v ...string) string
 
+	// Blockquote
+	Blockquote(v ...string) string
+
 	// Escape
 	Escape(v string) string
 }
@@ -61,13 +64,14 @@ var (
 		name:      "HTML",
 		separator: " ",
 
-		bold:      parseModeTag{"<b>", "</b>"},
-		italic:    parseModeTag{"<i>", "</i>"},
-		underline: parseModeTag{"<u>", "</u>"},
-		strike:    parseModeTag{"<s>", "</s>"},
-		spoiler:   parseModeTag{"<tg-spoiler>", "</tg-spoiler>"},
-		code:      parseModeTag{"<code>", "</code>"},
-		pre:       parseModeTag{"<pre>", "</pre>"},
+		bold:       parseModeTag{"<b>", "</b>"},
+		italic:     parseModeTag{"<i>", "</i>"},
+		underline:  parseModeTag{"<u>", "</u>"},
+		strike:     parseModeTag{"<s>", "</s>"},
+		spoiler:    parseModeTag{"<tg-spoiler>", "</tg-spoiler>"},
+		code:       parseModeTag{"<code>", "</code>"},
+		pre:        parseModeTag{"<pre>", "</pre>"},
+		blockquote: parseModeTag{"<blockquote>", "</blockquote>"},
 
 		linkTemplate: `<a href="{url}">{title}</a>`,
 
@@ -95,13 +99,14 @@ var (
 		name:      "MarkdownV2",
 		separator: " ",
 
-		bold:      parseModeTag{"*", "*"},
-		italic:    parseModeTag{"_", "_"},
-		underline: parseModeTag{"__", "__"},
-		strike:    parseModeTag{"~", "~"},
-		spoiler:   parseModeTag{"||", "||"},
-		code:      parseModeTag{"`", "`"},
-		pre:       parseModeTag{"```", "```"},
+		bold:       parseModeTag{"*", "*"},
+		italic:     parseModeTag{"_", "_"},
+		underline:  parseModeTag{"__", "__"},
+		strike:     parseModeTag{"~", "~"},
+		spoiler:    parseModeTag{"||", "||"},
+		code:       parseModeTag{"`", "`"},
+		pre:        parseModeTag{"```", "```"},
+		blockquote: parseModeTag{">", ""},
 
 		linkTemplate: `[{title}]({url})`,
 
@@ -121,6 +126,7 @@ type parseMode struct {
 	spoiler      parseModeTag
 	code         parseModeTag
 	pre          parseModeTag
+	blockquote   parseModeTag
 	linkTemplate string
 
 	escape func(string) string
@@ -197,6 +203,11 @@ func (pm parseMode) Code(v ...string) string {
 // Preformated text
 func (pm parseMode) Pre(v ...string) string {
 	return pm.pre.wrap(strings.Join(v, pm.separator))
+}
+
+// Blockquote
+func (pm parseMode) Blockquote(v ...string) string {
+	return pm.blockquote.wrap(strings.Join(v, pm.separator))
 }
 
 func (pm parseMode) Escape(v string) string {

--- a/parse_mode_test.go
+++ b/parse_mode_test.go
@@ -23,6 +23,7 @@ func TestParseModeHTML(t *testing.T) {
 	assert.Equal(t, "<code>Hello World</code>", HTML.Code("Hello World"))
 	assert.Equal(t, "<pre>Hello World</pre>", HTML.Pre("Hello World"))
 	assert.Equal(t, "<b>Hello, World</b>", HTML.Sep(", ").Bold("Hello", "World"))
+	assert.Equal(t, "<blockquote>Hello, World</blockquote>", HTML.Sep(", ").Blockquote("Hello", "World"))
 	assert.Equal(t, "Me &amp; You", HTML.Escape("Me & You"))
 }
 
@@ -55,6 +56,7 @@ func TestParseModeMarkdownV2(t *testing.T) {
 	assert.Equal(t, "[Hello World](https://telegram.org)", MD2.Link("Hello World", "https://telegram.org"))
 	assert.Equal(t, "`Hello World`", MD2.Code("Hello World"))
 	assert.Equal(t, "```Hello World```", MD2.Pre("Hello World"))
+	assert.Equal(t, ">Hello World", MD2.Blockquote("Hello World"))
 	assert.Equal(t, "*Hello, World*", MD2.Sep(", ").Bold("Hello", "World"))
 
 	assert.Equal(t, "\\[\\*go\\_tg\\*\\]", MD2.Escape("[*go_tg*]"))


### PR DESCRIPTION
adds support for the blockquote formatting option as documented here: https://core.telegram.org/bots/api#formatting-options

I needed this for my own implementation, figured I would share it upstream.

Thanks for writing this :)
