### PR TITLE
Add Paid reaction

### DIFF
--- a/reactions.go
+++ b/reactions.go
@@ -12,6 +12,7 @@ import (
 type ReactionType struct {
 	Emoji       *ReactionTypeEmoji
 	CustomEmoji *ReactionTypeCustomEmoji
+	Paid        *ReactionTypePaid
 }
 
 // NewReactionTypeEmoji returns ReactionType with emoji subtype.
@@ -32,6 +33,9 @@ func (reaction ReactionType) MarshalJSON() ([]byte, error) {
 	case reaction.CustomEmoji != nil:
 		reaction.CustomEmoji.Type = "custom_emoji"
 		return json.Marshal(reaction.CustomEmoji)
+	case reaction.Paid != nil:
+		reaction.Paid.Type = "paid"
+		return json.Marshal(reaction.Paid)
 	default:
 		return nil, fmt.Errorf("unknown ReactionType type")
 	}
@@ -53,7 +57,11 @@ func (reaction *ReactionType) UnmarshalJSON(v []byte) error {
 	case "custom_emoji":
 		reaction.CustomEmoji = &ReactionTypeCustomEmoji{}
 		return json.Unmarshal(v, reaction.CustomEmoji)
+	case "paid":
+		reaction.Paid = &ReactionTypePaid{}
+		return json.Unmarshal(v, reaction.Paid)
 	default:
+		fmt.Println(reaction)
 		return fmt.Errorf("unknown ReactionType type: %s", partial.Type)
 	}
 }

--- a/reactions.go
+++ b/reactions.go
@@ -61,7 +61,6 @@ func (reaction *ReactionType) UnmarshalJSON(v []byte) error {
 		reaction.Paid = &ReactionTypePaid{}
 		return json.Unmarshal(v, reaction.Paid)
 	default:
-		fmt.Println(reaction)
 		return fmt.Errorf("unknown ReactionType type: %s", partial.Type)
 	}
 }

--- a/types_gen.go
+++ b/types_gen.go
@@ -2064,6 +2064,12 @@ type ReactionTypeCustomEmoji struct {
 	CustomEmojiID string `json:"custom_emoji_id"`
 }
 
+// ReactionTypePaid
+type ReactionTypePaid struct {
+	// Type of the reaction, always “paid”
+	Type string `json:"type"`
+}
+
 // ReactionCount represents a reaction added to a message along with the number of times it was added.
 type ReactionCount struct {
 	// Type of the reaction


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new 'Paid' reaction type to the reaction system, enabling the handling and serialization of paid reactions alongside existing emoji and custom emoji types.

New Features:
- Introduce a new 'Paid' reaction type to the existing reaction system, allowing for reactions that are categorized as paid.

<!-- Generated by sourcery-ai[bot]: end summary -->