### PR TITLE
feat(gen): generate variant constructors for button types

### DIFF
--- a/_examples/calculator/main.go
+++ b/_examples/calculator/main.go
@@ -62,22 +62,22 @@ func main() {
 
 func newCalculatorMessageKeyboard() tg.InlineKeyboardMarkup {
 	layout := tg.NewButtonLayout[tg.InlineKeyboardButton](3).Row(
-		tg.NewInlineKeyboardButtonCallback("+", "+"),
-		tg.NewInlineKeyboardButtonCallback("-", "-"),
-		tg.NewInlineKeyboardButtonCallback("*", "*"),
-		tg.NewInlineKeyboardButtonCallback("/", "/"),
+		tg.NewInlineKeyboardButtonCallbackData("+", "+"),
+		tg.NewInlineKeyboardButtonCallbackData("-", "-"),
+		tg.NewInlineKeyboardButtonCallbackData("*", "*"),
+		tg.NewInlineKeyboardButtonCallbackData("/", "/"),
 	)
 
 	for i := 9; i >= 0; i-- {
 		text := strconv.Itoa(i)
 		layout.Insert(
-			tg.NewInlineKeyboardButtonCallback(text, text),
+			tg.NewInlineKeyboardButtonCallbackData(text, text),
 		)
 	}
 
 	layout.Insert(
-		tg.NewInlineKeyboardButtonCallback(".", "."),
-		tg.NewInlineKeyboardButtonCallback("=", "="),
+		tg.NewInlineKeyboardButtonCallbackData(".", "."),
+		tg.NewInlineKeyboardButtonCallbackData("=", "="),
 	)
 
 	return tg.NewInlineKeyboardMarkup(layout.Keyboard()...)

--- a/_spec/api.html
+++ b/_spec/api.html
@@ -18397,4 +18397,4 @@ removePreloadInit();
 </script>
   </body>
 </html>
-<!-- page generated in 58.71ms -->
+<!-- page generated in 49.38ms -->

--- a/gen/config.yaml
+++ b/gen/config.yaml
@@ -121,6 +121,24 @@ typegen:
     InlineQuery.chat_type: ChatType
     WebhookInfo.allowed_updates: "[]UpdateType"
 
+  # Variant constructors for types with mutually exclusive optional fields
+  variant_constructors:
+    - type: InlineKeyboardButton
+      base_field: text
+      defaults:
+        pay: "true"
+        callback_game: "&CallbackGame{}"
+
+    - type: KeyboardButton
+      base_field: text
+      include_base: true
+      defaults:
+        request_contact: "true"
+        request_location: "true"
+
+    - type: InlineQueryResultsButton
+      base_field: text
+
 methodgen:
   stringer_types:
     - ParseMode

--- a/gen/config/config.go
+++ b/gen/config/config.go
@@ -46,14 +46,25 @@ type TypeMethodDef struct {
 	Return string `yaml:"return"` // Return enum type name (e.g., "MessageType")
 }
 
+// VariantConstructorDef defines variant constructors for types with mutually exclusive optional fields.
+// Example: InlineKeyboardButton has text (required) + one of: url, callback_data, web_app, etc.
+type VariantConstructorDef struct {
+	Type        string            `yaml:"type"`                   // Type name (e.g., "InlineKeyboardButton")
+	BaseField   string            `yaml:"base_field"`             // Required field name (e.g., "text")
+	IncludeBase bool              `yaml:"include_base,omitempty"` // Generate base constructor (e.g., NewKeyboardButton)
+	Exclude     []string          `yaml:"exclude,omitempty"`      // Fields to exclude from variant generation
+	Defaults    map[string]string `yaml:"defaults,omitempty"`     // Default values for bool/pointer fields (field_name -> "true" or "&Type{}")
+}
+
 // TypeGen holds type generation configuration.
 type TypeGen struct {
-	Exclude        []string          `yaml:"exclude"`
-	NameOverrides  map[string]string `yaml:"name_overrides"`
-	TypeOverrides  map[string]string `yaml:"type_overrides"`
-	FieldTypeRules []FieldTypeRule   `yaml:"field_type_rules"`
-	Enums          []EnumGenDef      `yaml:"enums,omitempty"`
-	TypeMethods    []TypeMethodDef   `yaml:"type_methods,omitempty"`
+	Exclude             []string                `yaml:"exclude"`
+	NameOverrides       map[string]string       `yaml:"name_overrides"`
+	TypeOverrides       map[string]string       `yaml:"type_overrides"`
+	FieldTypeRules      []FieldTypeRule         `yaml:"field_type_rules"`
+	Enums               []EnumGenDef            `yaml:"enums,omitempty"`
+	TypeMethods         []TypeMethodDef         `yaml:"type_methods,omitempty"`
+	VariantConstructors []VariantConstructorDef `yaml:"variant_constructors,omitempty"`
 }
 
 // IsExcluded reports whether typeName should be skipped.

--- a/gen/typegen/generate.go
+++ b/gen/typegen/generate.go
@@ -240,7 +240,7 @@ func buildTemplateData(api *ir.API, cfg *config.TypeGen, rules *CompiledFieldTyp
 			log.Warn("type not found for variant_constructor", "type", vcCfg.Type)
 			continue
 		}
-		vc := buildVariantConstructors(irType, &vcCfg, cfg, rules, usedNameOverrides, usedTypeOverrides)
+		vc := buildVariantConstructors(irType, &vcCfg, cfg, rules, usedNameOverrides, usedTypeOverrides, log)
 		if vc != nil {
 			data.VariantConstructors = append(data.VariantConstructors, *vc)
 			log.Debug("generating variant constructors", "type", vcCfg.Type, "variants", len(vc.Variants))
@@ -591,7 +591,7 @@ func buildFieldCondition(goFieldName string, f *ir.Field) string {
 }
 
 // buildVariantConstructors creates variant constructor data for a type.
-func buildVariantConstructors(t *ir.Type, vcCfg *config.VariantConstructorDef, cfg *config.TypeGen, rules *CompiledFieldTypeRules, usedNames, usedTypes map[string]bool) *GoVariantConstructorType {
+func buildVariantConstructors(t *ir.Type, vcCfg *config.VariantConstructorDef, cfg *config.TypeGen, rules *CompiledFieldTypeRules, usedNames, usedTypes map[string]bool, log *slog.Logger) *GoVariantConstructorType {
 	// Find the base field.
 	var baseField *ir.Field
 	for i := range t.Fields {
@@ -601,6 +601,7 @@ func buildVariantConstructors(t *ir.Type, vcCfg *config.VariantConstructorDef, c
 		}
 	}
 	if baseField == nil {
+		log.Warn("base_field not found for variant_constructor", "type", vcCfg.Type, "base_field", vcCfg.BaseField)
 		return nil
 	}
 

--- a/gen/typegen/generate.go
+++ b/gen/typegen/generate.go
@@ -83,16 +83,39 @@ type GoTypeMethodCase struct {
 	Condition string // condition expression, e.g. "v.Text != \"\""
 }
 
+// GoVariantConstructorType holds all variants for a single type.
+type GoVariantConstructorType struct {
+	TypeName    string                 // e.g. "InlineKeyboardButton"
+	BaseGoField string                 // e.g. "Text"
+	BaseGoType  string                 // e.g. "string"
+	BaseParam   string                 // e.g. "text string"
+	BaseArg     string                 // e.g. "text"
+	Variants    []GoVariantConstructor // list of variants
+}
+
+// GoVariantConstructor represents a single variant constructor.
+type GoVariantConstructor struct {
+	Name         string // e.g. "URL" -> NewInlineKeyboardButtonURL
+	GoField      string // e.g. "URL"
+	GoType       string // e.g. "string"
+	Param        string // e.g. "url string" (empty if HasDefault)
+	Arg          string // e.g. "url" (empty if HasDefault)
+	HasDefault   bool   // true if uses default value instead of param
+	DefaultValue string // e.g. "true" or "&CallbackGame{}"
+	Comment      string // e.g. "with URL"
+}
+
 // TemplateData is the data passed to the template.
 type TemplateData struct {
 	Package string
 	ir.Metadata
-	Types       []GoType
-	UnionTypes  []GoUnionType
-	Enums       []GoEnum
-	TypeMethods []GoTypeMethod
-	NeedJSON    bool
-	NeedFmt     bool
+	Types               []GoType
+	UnionTypes          []GoUnionType
+	Enums               []GoEnum
+	TypeMethods         []GoTypeMethod
+	VariantConstructors []GoVariantConstructorType
+	NeedJSON            bool
+	NeedFmt             bool
 }
 
 // Options controls generation behavior.
@@ -210,7 +233,26 @@ func buildTemplateData(api *ir.API, cfg *config.TypeGen, rules *CompiledFieldTyp
 		log.Debug("generating type method", "type", methodCfg.Type, "method", methodCfg.Method, "cases", len(goMethod.Cases))
 	}
 
-	// Warn about unused config entries.
+	// Resolve variant constructors (e.g., NewInlineKeyboardButtonURL).
+	for _, vcCfg := range cfg.VariantConstructors {
+		irType := findType(api.Types, vcCfg.Type)
+		if irType == nil {
+			log.Warn("type not found for variant_constructor", "type", vcCfg.Type)
+			continue
+		}
+		vc := buildVariantConstructors(irType, &vcCfg, cfg, rules, usedNameOverrides, usedTypeOverrides)
+		if vc != nil {
+			data.VariantConstructors = append(data.VariantConstructors, *vc)
+			log.Debug("generating variant constructors", "type", vcCfg.Type, "variants", len(vc.Variants))
+		}
+	}
+
+	warnUnusedConfig(cfg, rules, usedExcludes, usedNameOverrides, usedTypeOverrides, log)
+
+	return data
+}
+
+func warnUnusedConfig(cfg *config.TypeGen, rules *CompiledFieldTypeRules, usedExcludes, usedNameOverrides, usedTypeOverrides map[string]bool, log *slog.Logger) {
 	for _, name := range cfg.Exclude {
 		if !usedExcludes[name] {
 			log.Warn("unused exclude entry", "name", name)
@@ -229,8 +271,6 @@ func buildTemplateData(api *ir.API, cfg *config.TypeGen, rules *CompiledFieldTyp
 	for _, expr := range rules.Unmatched() {
 		log.Warn("unmatched field_type_rule", "expr", expr)
 	}
-
-	return data
 }
 
 func resolveType(t ir.Type, cfg *config.TypeGen, rules *CompiledFieldTypeRules, usedNames, usedTypes map[string]bool) GoType {
@@ -548,4 +588,88 @@ func buildFieldCondition(goFieldName string, f *ir.Field) string {
 		// Complex type (pointer)
 		return "v." + goFieldName + " != nil"
 	}
+}
+
+// buildVariantConstructors creates variant constructor data for a type.
+func buildVariantConstructors(t *ir.Type, vcCfg *config.VariantConstructorDef, cfg *config.TypeGen, rules *CompiledFieldTypeRules, usedNames, usedTypes map[string]bool) *GoVariantConstructorType {
+	// Find the base field.
+	var baseField *ir.Field
+	for i := range t.Fields {
+		if t.Fields[i].Name == vcCfg.BaseField {
+			baseField = &t.Fields[i]
+			break
+		}
+	}
+	if baseField == nil {
+		return nil
+	}
+
+	typeName := normalizeTypeName(t.Name)
+	baseGoField := snakeToPascal(baseField.Name)
+	baseGoType := resolveGoType(t.Name, *baseField, cfg, rules, usedTypes)
+	baseArgName := snakeToCamel(baseField.Name)
+
+	vc := &GoVariantConstructorType{
+		TypeName:    typeName,
+		BaseGoField: baseGoField,
+		BaseGoType:  baseGoType,
+		BaseParam:   baseArgName + " " + baseGoType,
+		BaseArg:     baseArgName,
+	}
+
+	// Check if field should be excluded.
+	isExcluded := func(fieldName string) bool {
+		for _, ex := range vcCfg.Exclude {
+			if ex == fieldName {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Generate base constructor if requested (e.g., NewKeyboardButton).
+	if vcCfg.IncludeBase {
+		vc.Variants = append(vc.Variants, GoVariantConstructor{
+			Name:    "",
+			Comment: "",
+		})
+	}
+
+	// Generate variant for each optional field.
+	for _, f := range t.Fields {
+		if !f.Optional || f.Name == vcCfg.BaseField || isExcluded(f.Name) {
+			continue
+		}
+
+		goFieldName := resolveFieldName(t.Name, f.Name, cfg, usedNames)
+		goType := resolveGoType(t.Name, f, cfg, rules, usedTypes)
+		argName := snakeToCamel(f.Name)
+
+		variant := GoVariantConstructor{
+			Name:    goFieldName,
+			GoField: goFieldName,
+			GoType:  goType,
+			Comment: "with " + goFieldName,
+		}
+
+		// Check if this field has a default value configured.
+		if defaultVal, ok := vcCfg.Defaults[f.Name]; ok {
+			variant.HasDefault = true
+			variant.DefaultValue = defaultVal
+		} else {
+			// For pointer types, accept value and take address in constructor.
+			paramType := goType
+			arg := argName
+			if strings.HasPrefix(goType, "*") {
+				paramType = goType[1:] // Remove "*" from param type
+				arg = "&" + argName    // Add "&" when assigning
+			}
+			variant.Param = argName + " " + paramType
+			variant.Arg = arg
+		}
+
+		vc.Variants = append(vc.Variants, variant)
+	}
+
+	return vc
 }

--- a/gen/typegen/names.go
+++ b/gen/typegen/names.go
@@ -11,3 +11,8 @@ func normalizeTypeName(name string) string {
 func snakeToPascal(s string) string {
 	return naming.SnakeToPascal(s)
 }
+
+// snakeToCamel converts a snake_case string to camelCase.
+func snakeToCamel(s string) string {
+	return naming.SnakeToCamel(s)
+}

--- a/gen/typegen/types.go.tmpl
+++ b/gen/typegen/types.go.tmpl
@@ -221,7 +221,7 @@ func (v *{{$m.TypeName}}) {{$m.MethodName}}() {{$m.ReturnType}} {
 {{end}}
 {{- range $vc := .VariantConstructors}}
 {{- range $v := $vc.Variants}}
-// New{{$vc.TypeName}}{{$v.Name}} creates a {{$vc.TypeName}}{{if $v.Comment}} {{$v.Comment}}{{end}}.
+// New{{$vc.TypeName}}{{$v.Name}} creates {{$vc.TypeName}}{{if $v.Comment}} {{$v.Comment}}{{end}}.
 func New{{$vc.TypeName}}{{$v.Name}}({{$vc.BaseParam}}{{if and $v.Param (not $v.HasDefault)}}, {{$v.Param}}{{end}}) {{$vc.TypeName}} {
 	return {{$vc.TypeName}}{
 		{{$vc.BaseGoField}}: {{$vc.BaseArg}},

--- a/gen/typegen/types.go.tmpl
+++ b/gen/typegen/types.go.tmpl
@@ -219,3 +219,16 @@ func (v *{{$m.TypeName}}) {{$m.MethodName}}() {{$m.ReturnType}} {
 	}
 }
 {{end}}
+{{- range $vc := .VariantConstructors}}
+{{- range $v := $vc.Variants}}
+// New{{$vc.TypeName}}{{$v.Name}} creates a {{$vc.TypeName}}{{if $v.Comment}} {{$v.Comment}}{{end}}.
+func New{{$vc.TypeName}}{{$v.Name}}({{$vc.BaseParam}}{{if and $v.Param (not $v.HasDefault)}}, {{$v.Param}}{{end}}) {{$vc.TypeName}} {
+	return {{$vc.TypeName}}{
+		{{$vc.BaseGoField}}: {{$vc.BaseArg}},
+{{- if $v.GoField}}
+		{{$v.GoField}}: {{if $v.HasDefault}}{{$v.DefaultValue}}{{else}}{{$v.Arg}}{{end}},
+{{- end}}
+	}
+}
+{{end}}
+{{- end}}

--- a/tgb/callback_data.go
+++ b/tgb/callback_data.go
@@ -326,7 +326,7 @@ func (p *CallbackDataFilter[T]) MustButton(text string, v T) tg.InlineKeyboardBu
 		return tg.InlineKeyboardButton{}
 	}
 
-	return tg.NewInlineKeyboardButtonCallback(text, data)
+	return tg.NewInlineKeyboardButtonCallbackData(text, data)
 }
 
 // Button returns a new tg.InlineKeyboardButton with the given data as callback data.
@@ -337,7 +337,7 @@ func (p *CallbackDataFilter[T]) Button(text string, v T) (tg.InlineKeyboardButto
 		return tg.InlineKeyboardButton{}, fmt.Errorf("encode: %w", err)
 	}
 
-	return tg.NewInlineKeyboardButtonCallback(text, data), nil
+	return tg.NewInlineKeyboardButtonCallbackData(text, data), nil
 }
 
 // Encode serializes a struct into callback data using the filter's parser.

--- a/tgb/handler_gen.go
+++ b/tgb/handler_gen.go
@@ -17,37 +17,18 @@ func firstNotNil[T any](fields ...*T) *T {
 	return nil
 }
 
-// ShippingQueryHandler it's typed handler for ShippingQuery.
+// ChatMemberUpdatedHandler it's typed handler for ChatMemberUpdated.
 // Implements Handler interface.
-type ShippingQueryHandler func(context.Context, *ShippingQueryUpdate) error
+type ChatMemberUpdatedHandler func(context.Context, *ChatMemberUpdatedUpdate) error
 
-func (handler ShippingQueryHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &ShippingQueryUpdate{
-		ShippingQuery: update.ShippingQuery,
-		BaseUpdate:    BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// PreCheckoutQueryHandler it's typed handler for PreCheckoutQuery.
-// Implements Handler interface.
-type PreCheckoutQueryHandler func(context.Context, *PreCheckoutQueryUpdate) error
-
-func (handler PreCheckoutQueryHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &PreCheckoutQueryUpdate{
-		PreCheckoutQuery: update.PreCheckoutQuery,
-		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// ChatBoostHandler it's typed handler for ChatBoostUpdated.
-// Implements Handler interface.
-type ChatBoostHandler func(context.Context, *ChatBoostUpdate) error
-
-func (handler ChatBoostHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &ChatBoostUpdate{
-		ChatBoostUpdated: update.ChatBoost,
-		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
-	})
+func (handler ChatMemberUpdatedHandler) Handle(ctx context.Context, update *Update) error {
+	if v := firstNotNil(update.MyChatMember, update.ChatMember); v != nil {
+		return handler(ctx, &ChatMemberUpdatedUpdate{
+			ChatMemberUpdated: v,
+			BaseUpdate:        BaseUpdate{Update: update, Client: update.Client},
+		})
+	}
+	return nil
 }
 
 // MessageHandler it's typed handler for Message.
@@ -64,53 +45,6 @@ func (handler MessageHandler) Handle(ctx context.Context, update *Update) error 
 	return nil
 }
 
-// PollAnswerHandler it's typed handler for PollAnswer.
-// Implements Handler interface.
-type PollAnswerHandler func(context.Context, *PollAnswerUpdate) error
-
-func (handler PollAnswerHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &PollAnswerUpdate{
-		PollAnswer: update.PollAnswer,
-		BaseUpdate: BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// PollHandler it's typed handler for Poll.
-// Implements Handler interface.
-type PollHandler func(context.Context, *PollUpdate) error
-
-func (handler PollHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &PollUpdate{
-		Poll:       update.Poll,
-		BaseUpdate: BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// ChatMemberUpdatedHandler it's typed handler for ChatMemberUpdated.
-// Implements Handler interface.
-type ChatMemberUpdatedHandler func(context.Context, *ChatMemberUpdatedUpdate) error
-
-func (handler ChatMemberUpdatedHandler) Handle(ctx context.Context, update *Update) error {
-	if v := firstNotNil(update.MyChatMember, update.ChatMember); v != nil {
-		return handler(ctx, &ChatMemberUpdatedUpdate{
-			ChatMemberUpdated: v,
-			BaseUpdate:        BaseUpdate{Update: update, Client: update.Client},
-		})
-	}
-	return nil
-}
-
-// BusinessConnectionHandler it's typed handler for BusinessConnection.
-// Implements Handler interface.
-type BusinessConnectionHandler func(context.Context, *BusinessConnectionUpdate) error
-
-func (handler BusinessConnectionHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &BusinessConnectionUpdate{
-		BusinessConnection: update.BusinessConnection,
-		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
 // InlineQueryHandler it's typed handler for InlineQuery.
 // Implements Handler interface.
 type InlineQueryHandler func(context.Context, *InlineQueryUpdate) error
@@ -122,35 +56,13 @@ func (handler InlineQueryHandler) Handle(ctx context.Context, update *Update) er
 	})
 }
 
-// CallbackQueryHandler it's typed handler for CallbackQuery.
+// PurchasedPaidMediaHandler it's typed handler for PaidMediaPurchased.
 // Implements Handler interface.
-type CallbackQueryHandler func(context.Context, *CallbackQueryUpdate) error
+type PurchasedPaidMediaHandler func(context.Context, *PurchasedPaidMediaUpdate) error
 
-func (handler CallbackQueryHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &CallbackQueryUpdate{
-		CallbackQuery: update.CallbackQuery,
-		BaseUpdate:    BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// RemovedChatBoostHandler it's typed handler for ChatBoostRemoved.
-// Implements Handler interface.
-type RemovedChatBoostHandler func(context.Context, *RemovedChatBoostUpdate) error
-
-func (handler RemovedChatBoostHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &RemovedChatBoostUpdate{
-		ChatBoostRemoved: update.RemovedChatBoost,
-		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// ChosenInlineResultHandler it's typed handler for ChosenInlineResult.
-// Implements Handler interface.
-type ChosenInlineResultHandler func(context.Context, *ChosenInlineResultUpdate) error
-
-func (handler ChosenInlineResultHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &ChosenInlineResultUpdate{
-		ChosenInlineResult: update.ChosenInlineResult,
+func (handler PurchasedPaidMediaHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &PurchasedPaidMediaUpdate{
+		PaidMediaPurchased: update.PurchasedPaidMedia,
 		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
 	})
 }
@@ -166,14 +78,25 @@ func (handler ChatJoinRequestHandler) Handle(ctx context.Context, update *Update
 	})
 }
 
-// PurchasedPaidMediaHandler it's typed handler for PaidMediaPurchased.
+// RemovedChatBoostHandler it's typed handler for ChatBoostRemoved.
 // Implements Handler interface.
-type PurchasedPaidMediaHandler func(context.Context, *PurchasedPaidMediaUpdate) error
+type RemovedChatBoostHandler func(context.Context, *RemovedChatBoostUpdate) error
 
-func (handler PurchasedPaidMediaHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &PurchasedPaidMediaUpdate{
-		PaidMediaPurchased: update.PurchasedPaidMedia,
-		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
+func (handler RemovedChatBoostHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &RemovedChatBoostUpdate{
+		ChatBoostRemoved: update.RemovedChatBoost,
+		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// ShippingQueryHandler it's typed handler for ShippingQuery.
+// Implements Handler interface.
+type ShippingQueryHandler func(context.Context, *ShippingQueryUpdate) error
+
+func (handler ShippingQueryHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &ShippingQueryUpdate{
+		ShippingQuery: update.ShippingQuery,
+		BaseUpdate:    BaseUpdate{Update: update, Client: update.Client},
 	})
 }
 
@@ -185,6 +108,39 @@ func (handler DeletedBusinessMessagesHandler) Handle(ctx context.Context, update
 	return handler(ctx, &DeletedBusinessMessagesUpdate{
 		BusinessMessagesDeleted: update.DeletedBusinessMessages,
 		BaseUpdate:              BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// ChosenInlineResultHandler it's typed handler for ChosenInlineResult.
+// Implements Handler interface.
+type ChosenInlineResultHandler func(context.Context, *ChosenInlineResultUpdate) error
+
+func (handler ChosenInlineResultHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &ChosenInlineResultUpdate{
+		ChosenInlineResult: update.ChosenInlineResult,
+		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// ChatBoostHandler it's typed handler for ChatBoostUpdated.
+// Implements Handler interface.
+type ChatBoostHandler func(context.Context, *ChatBoostUpdate) error
+
+func (handler ChatBoostHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &ChatBoostUpdate{
+		ChatBoostUpdated: update.ChatBoost,
+		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// BusinessConnectionHandler it's typed handler for BusinessConnection.
+// Implements Handler interface.
+type BusinessConnectionHandler func(context.Context, *BusinessConnectionUpdate) error
+
+func (handler BusinessConnectionHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &BusinessConnectionUpdate{
+		BusinessConnection: update.BusinessConnection,
+		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
 	})
 }
 
@@ -207,5 +163,49 @@ func (handler MessageReactionCountHandler) Handle(ctx context.Context, update *U
 	return handler(ctx, &MessageReactionCountUpdate{
 		MessageReactionCountUpdated: update.MessageReactionCount,
 		BaseUpdate:                  BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// CallbackQueryHandler it's typed handler for CallbackQuery.
+// Implements Handler interface.
+type CallbackQueryHandler func(context.Context, *CallbackQueryUpdate) error
+
+func (handler CallbackQueryHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &CallbackQueryUpdate{
+		CallbackQuery: update.CallbackQuery,
+		BaseUpdate:    BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// PreCheckoutQueryHandler it's typed handler for PreCheckoutQuery.
+// Implements Handler interface.
+type PreCheckoutQueryHandler func(context.Context, *PreCheckoutQueryUpdate) error
+
+func (handler PreCheckoutQueryHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &PreCheckoutQueryUpdate{
+		PreCheckoutQuery: update.PreCheckoutQuery,
+		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// PollHandler it's typed handler for Poll.
+// Implements Handler interface.
+type PollHandler func(context.Context, *PollUpdate) error
+
+func (handler PollHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &PollUpdate{
+		Poll:       update.Poll,
+		BaseUpdate: BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// PollAnswerHandler it's typed handler for PollAnswer.
+// Implements Handler interface.
+type PollAnswerHandler func(context.Context, *PollAnswerUpdate) error
+
+func (handler PollAnswerHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &PollAnswerUpdate{
+		PollAnswer: update.PollAnswer,
+		BaseUpdate: BaseUpdate{Update: update, Client: update.Client},
 	})
 }

--- a/tgb/handler_gen.go
+++ b/tgb/handler_gen.go
@@ -17,6 +17,28 @@ func firstNotNil[T any](fields ...*T) *T {
 	return nil
 }
 
+// ShippingQueryHandler it's typed handler for ShippingQuery.
+// Implements Handler interface.
+type ShippingQueryHandler func(context.Context, *ShippingQueryUpdate) error
+
+func (handler ShippingQueryHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &ShippingQueryUpdate{
+		ShippingQuery: update.ShippingQuery,
+		BaseUpdate:    BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// PreCheckoutQueryHandler it's typed handler for PreCheckoutQuery.
+// Implements Handler interface.
+type PreCheckoutQueryHandler func(context.Context, *PreCheckoutQueryUpdate) error
+
+func (handler PreCheckoutQueryHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &PreCheckoutQueryUpdate{
+		PreCheckoutQuery: update.PreCheckoutQuery,
+		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
 // ChatBoostHandler it's typed handler for ChatBoostUpdated.
 // Implements Handler interface.
 type ChatBoostHandler func(context.Context, *ChatBoostUpdate) error
@@ -25,17 +47,6 @@ func (handler ChatBoostHandler) Handle(ctx context.Context, update *Update) erro
 	return handler(ctx, &ChatBoostUpdate{
 		ChatBoostUpdated: update.ChatBoost,
 		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// CallbackQueryHandler it's typed handler for CallbackQuery.
-// Implements Handler interface.
-type CallbackQueryHandler func(context.Context, *CallbackQueryUpdate) error
-
-func (handler CallbackQueryHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &CallbackQueryUpdate{
-		CallbackQuery: update.CallbackQuery,
-		BaseUpdate:    BaseUpdate{Update: update, Client: update.Client},
 	})
 }
 
@@ -53,83 +64,6 @@ func (handler MessageHandler) Handle(ctx context.Context, update *Update) error 
 	return nil
 }
 
-// DeletedBusinessMessagesHandler it's typed handler for BusinessMessagesDeleted.
-// Implements Handler interface.
-type DeletedBusinessMessagesHandler func(context.Context, *DeletedBusinessMessagesUpdate) error
-
-func (handler DeletedBusinessMessagesHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &DeletedBusinessMessagesUpdate{
-		BusinessMessagesDeleted: update.DeletedBusinessMessages,
-		BaseUpdate:              BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// ChosenInlineResultHandler it's typed handler for ChosenInlineResult.
-// Implements Handler interface.
-type ChosenInlineResultHandler func(context.Context, *ChosenInlineResultUpdate) error
-
-func (handler ChosenInlineResultHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &ChosenInlineResultUpdate{
-		ChosenInlineResult: update.ChosenInlineResult,
-		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// RemovedChatBoostHandler it's typed handler for ChatBoostRemoved.
-// Implements Handler interface.
-type RemovedChatBoostHandler func(context.Context, *RemovedChatBoostUpdate) error
-
-func (handler RemovedChatBoostHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &RemovedChatBoostUpdate{
-		ChatBoostRemoved: update.RemovedChatBoost,
-		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// InlineQueryHandler it's typed handler for InlineQuery.
-// Implements Handler interface.
-type InlineQueryHandler func(context.Context, *InlineQueryUpdate) error
-
-func (handler InlineQueryHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &InlineQueryUpdate{
-		InlineQuery: update.InlineQuery,
-		BaseUpdate:  BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// ShippingQueryHandler it's typed handler for ShippingQuery.
-// Implements Handler interface.
-type ShippingQueryHandler func(context.Context, *ShippingQueryUpdate) error
-
-func (handler ShippingQueryHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &ShippingQueryUpdate{
-		ShippingQuery: update.ShippingQuery,
-		BaseUpdate:    BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// PurchasedPaidMediaHandler it's typed handler for PaidMediaPurchased.
-// Implements Handler interface.
-type PurchasedPaidMediaHandler func(context.Context, *PurchasedPaidMediaUpdate) error
-
-func (handler PurchasedPaidMediaHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &PurchasedPaidMediaUpdate{
-		PaidMediaPurchased: update.PurchasedPaidMedia,
-		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// ChatJoinRequestHandler it's typed handler for ChatJoinRequest.
-// Implements Handler interface.
-type ChatJoinRequestHandler func(context.Context, *ChatJoinRequestUpdate) error
-
-func (handler ChatJoinRequestHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &ChatJoinRequestUpdate{
-		ChatJoinRequest: update.ChatJoinRequest,
-		BaseUpdate:      BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
 // PollAnswerHandler it's typed handler for PollAnswer.
 // Implements Handler interface.
 type PollAnswerHandler func(context.Context, *PollAnswerUpdate) error
@@ -137,6 +71,17 @@ type PollAnswerHandler func(context.Context, *PollAnswerUpdate) error
 func (handler PollAnswerHandler) Handle(ctx context.Context, update *Update) error {
 	return handler(ctx, &PollAnswerUpdate{
 		PollAnswer: update.PollAnswer,
+		BaseUpdate: BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// PollHandler it's typed handler for Poll.
+// Implements Handler interface.
+type PollHandler func(context.Context, *PollUpdate) error
+
+func (handler PollHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &PollUpdate{
+		Poll:       update.Poll,
 		BaseUpdate: BaseUpdate{Update: update, Client: update.Client},
 	})
 }
@@ -166,6 +111,83 @@ func (handler BusinessConnectionHandler) Handle(ctx context.Context, update *Upd
 	})
 }
 
+// InlineQueryHandler it's typed handler for InlineQuery.
+// Implements Handler interface.
+type InlineQueryHandler func(context.Context, *InlineQueryUpdate) error
+
+func (handler InlineQueryHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &InlineQueryUpdate{
+		InlineQuery: update.InlineQuery,
+		BaseUpdate:  BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// CallbackQueryHandler it's typed handler for CallbackQuery.
+// Implements Handler interface.
+type CallbackQueryHandler func(context.Context, *CallbackQueryUpdate) error
+
+func (handler CallbackQueryHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &CallbackQueryUpdate{
+		CallbackQuery: update.CallbackQuery,
+		BaseUpdate:    BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// RemovedChatBoostHandler it's typed handler for ChatBoostRemoved.
+// Implements Handler interface.
+type RemovedChatBoostHandler func(context.Context, *RemovedChatBoostUpdate) error
+
+func (handler RemovedChatBoostHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &RemovedChatBoostUpdate{
+		ChatBoostRemoved: update.RemovedChatBoost,
+		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// ChosenInlineResultHandler it's typed handler for ChosenInlineResult.
+// Implements Handler interface.
+type ChosenInlineResultHandler func(context.Context, *ChosenInlineResultUpdate) error
+
+func (handler ChosenInlineResultHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &ChosenInlineResultUpdate{
+		ChosenInlineResult: update.ChosenInlineResult,
+		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// ChatJoinRequestHandler it's typed handler for ChatJoinRequest.
+// Implements Handler interface.
+type ChatJoinRequestHandler func(context.Context, *ChatJoinRequestUpdate) error
+
+func (handler ChatJoinRequestHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &ChatJoinRequestUpdate{
+		ChatJoinRequest: update.ChatJoinRequest,
+		BaseUpdate:      BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// PurchasedPaidMediaHandler it's typed handler for PaidMediaPurchased.
+// Implements Handler interface.
+type PurchasedPaidMediaHandler func(context.Context, *PurchasedPaidMediaUpdate) error
+
+func (handler PurchasedPaidMediaHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &PurchasedPaidMediaUpdate{
+		PaidMediaPurchased: update.PurchasedPaidMedia,
+		BaseUpdate:         BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
+// DeletedBusinessMessagesHandler it's typed handler for BusinessMessagesDeleted.
+// Implements Handler interface.
+type DeletedBusinessMessagesHandler func(context.Context, *DeletedBusinessMessagesUpdate) error
+
+func (handler DeletedBusinessMessagesHandler) Handle(ctx context.Context, update *Update) error {
+	return handler(ctx, &DeletedBusinessMessagesUpdate{
+		BusinessMessagesDeleted: update.DeletedBusinessMessages,
+		BaseUpdate:              BaseUpdate{Update: update, Client: update.Client},
+	})
+}
+
 // MessageReactionHandler it's typed handler for MessageReactionUpdated.
 // Implements Handler interface.
 type MessageReactionHandler func(context.Context, *MessageReactionUpdate) error
@@ -185,27 +207,5 @@ func (handler MessageReactionCountHandler) Handle(ctx context.Context, update *U
 	return handler(ctx, &MessageReactionCountUpdate{
 		MessageReactionCountUpdated: update.MessageReactionCount,
 		BaseUpdate:                  BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// PreCheckoutQueryHandler it's typed handler for PreCheckoutQuery.
-// Implements Handler interface.
-type PreCheckoutQueryHandler func(context.Context, *PreCheckoutQueryUpdate) error
-
-func (handler PreCheckoutQueryHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &PreCheckoutQueryUpdate{
-		PreCheckoutQuery: update.PreCheckoutQuery,
-		BaseUpdate:       BaseUpdate{Update: update, Client: update.Client},
-	})
-}
-
-// PollHandler it's typed handler for Poll.
-// Implements Handler interface.
-type PollHandler func(context.Context, *PollUpdate) error
-
-func (handler PollHandler) Handle(ctx context.Context, update *Update) error {
-	return handler(ctx, &PollUpdate{
-		Poll:       update.Poll,
-		BaseUpdate: BaseUpdate{Update: update, Client: update.Client},
 	})
 }

--- a/tgb/update_gen.go
+++ b/tgb/update_gen.go
@@ -14,21 +14,9 @@ type BaseUpdate struct {
 	Client *tg.Client
 }
 
-// ShippingQueryUpdate it's extend wrapper around [tg.ShippingQuery].
-type ShippingQueryUpdate struct {
-	*tg.ShippingQuery
-	BaseUpdate
-}
-
-// PreCheckoutQueryUpdate it's extend wrapper around [tg.PreCheckoutQuery].
-type PreCheckoutQueryUpdate struct {
-	*tg.PreCheckoutQuery
-	BaseUpdate
-}
-
-// ChatBoostUpdate it's extend wrapper around [tg.ChatBoostUpdated].
-type ChatBoostUpdate struct {
-	*tg.ChatBoostUpdated
+// ChatMemberUpdatedUpdate it's extend wrapper around [tg.ChatMemberUpdated].
+type ChatMemberUpdatedUpdate struct {
+	*tg.ChatMemberUpdated
 	BaseUpdate
 }
 
@@ -38,57 +26,9 @@ type MessageUpdate struct {
 	BaseUpdate
 }
 
-// PollAnswerUpdate it's extend wrapper around [tg.PollAnswer].
-type PollAnswerUpdate struct {
-	*tg.PollAnswer
-	BaseUpdate
-}
-
-// PollUpdate it's extend wrapper around [tg.Poll].
-type PollUpdate struct {
-	*tg.Poll
-	BaseUpdate
-}
-
-// ChatMemberUpdatedUpdate it's extend wrapper around [tg.ChatMemberUpdated].
-type ChatMemberUpdatedUpdate struct {
-	*tg.ChatMemberUpdated
-	BaseUpdate
-}
-
-// BusinessConnectionUpdate it's extend wrapper around [tg.BusinessConnection].
-type BusinessConnectionUpdate struct {
-	*tg.BusinessConnection
-	BaseUpdate
-}
-
 // InlineQueryUpdate it's extend wrapper around [tg.InlineQuery].
 type InlineQueryUpdate struct {
 	*tg.InlineQuery
-	BaseUpdate
-}
-
-// CallbackQueryUpdate it's extend wrapper around [tg.CallbackQuery].
-type CallbackQueryUpdate struct {
-	*tg.CallbackQuery
-	BaseUpdate
-}
-
-// RemovedChatBoostUpdate it's extend wrapper around [tg.ChatBoostRemoved].
-type RemovedChatBoostUpdate struct {
-	*tg.ChatBoostRemoved
-	BaseUpdate
-}
-
-// ChosenInlineResultUpdate it's extend wrapper around [tg.ChosenInlineResult].
-type ChosenInlineResultUpdate struct {
-	*tg.ChosenInlineResult
-	BaseUpdate
-}
-
-// ChatJoinRequestUpdate it's extend wrapper around [tg.ChatJoinRequest].
-type ChatJoinRequestUpdate struct {
-	*tg.ChatJoinRequest
 	BaseUpdate
 }
 
@@ -98,9 +38,45 @@ type PurchasedPaidMediaUpdate struct {
 	BaseUpdate
 }
 
+// ChatJoinRequestUpdate it's extend wrapper around [tg.ChatJoinRequest].
+type ChatJoinRequestUpdate struct {
+	*tg.ChatJoinRequest
+	BaseUpdate
+}
+
+// RemovedChatBoostUpdate it's extend wrapper around [tg.ChatBoostRemoved].
+type RemovedChatBoostUpdate struct {
+	*tg.ChatBoostRemoved
+	BaseUpdate
+}
+
+// ShippingQueryUpdate it's extend wrapper around [tg.ShippingQuery].
+type ShippingQueryUpdate struct {
+	*tg.ShippingQuery
+	BaseUpdate
+}
+
 // DeletedBusinessMessagesUpdate it's extend wrapper around [tg.BusinessMessagesDeleted].
 type DeletedBusinessMessagesUpdate struct {
 	*tg.BusinessMessagesDeleted
+	BaseUpdate
+}
+
+// ChosenInlineResultUpdate it's extend wrapper around [tg.ChosenInlineResult].
+type ChosenInlineResultUpdate struct {
+	*tg.ChosenInlineResult
+	BaseUpdate
+}
+
+// ChatBoostUpdate it's extend wrapper around [tg.ChatBoostUpdated].
+type ChatBoostUpdate struct {
+	*tg.ChatBoostUpdated
+	BaseUpdate
+}
+
+// BusinessConnectionUpdate it's extend wrapper around [tg.BusinessConnection].
+type BusinessConnectionUpdate struct {
+	*tg.BusinessConnection
 	BaseUpdate
 }
 
@@ -113,5 +89,29 @@ type MessageReactionUpdate struct {
 // MessageReactionCountUpdate it's extend wrapper around [tg.MessageReactionCountUpdated].
 type MessageReactionCountUpdate struct {
 	*tg.MessageReactionCountUpdated
+	BaseUpdate
+}
+
+// CallbackQueryUpdate it's extend wrapper around [tg.CallbackQuery].
+type CallbackQueryUpdate struct {
+	*tg.CallbackQuery
+	BaseUpdate
+}
+
+// PreCheckoutQueryUpdate it's extend wrapper around [tg.PreCheckoutQuery].
+type PreCheckoutQueryUpdate struct {
+	*tg.PreCheckoutQuery
+	BaseUpdate
+}
+
+// PollUpdate it's extend wrapper around [tg.Poll].
+type PollUpdate struct {
+	*tg.Poll
+	BaseUpdate
+}
+
+// PollAnswerUpdate it's extend wrapper around [tg.PollAnswer].
+type PollAnswerUpdate struct {
+	*tg.PollAnswer
 	BaseUpdate
 }

--- a/tgb/update_gen.go
+++ b/tgb/update_gen.go
@@ -14,15 +14,21 @@ type BaseUpdate struct {
 	Client *tg.Client
 }
 
-// ChatBoostUpdate it's extend wrapper around [tg.ChatBoostUpdated].
-type ChatBoostUpdate struct {
-	*tg.ChatBoostUpdated
+// ShippingQueryUpdate it's extend wrapper around [tg.ShippingQuery].
+type ShippingQueryUpdate struct {
+	*tg.ShippingQuery
 	BaseUpdate
 }
 
-// CallbackQueryUpdate it's extend wrapper around [tg.CallbackQuery].
-type CallbackQueryUpdate struct {
-	*tg.CallbackQuery
+// PreCheckoutQueryUpdate it's extend wrapper around [tg.PreCheckoutQuery].
+type PreCheckoutQueryUpdate struct {
+	*tg.PreCheckoutQuery
+	BaseUpdate
+}
+
+// ChatBoostUpdate it's extend wrapper around [tg.ChatBoostUpdated].
+type ChatBoostUpdate struct {
+	*tg.ChatBoostUpdated
 	BaseUpdate
 }
 
@@ -32,51 +38,15 @@ type MessageUpdate struct {
 	BaseUpdate
 }
 
-// DeletedBusinessMessagesUpdate it's extend wrapper around [tg.BusinessMessagesDeleted].
-type DeletedBusinessMessagesUpdate struct {
-	*tg.BusinessMessagesDeleted
-	BaseUpdate
-}
-
-// ChosenInlineResultUpdate it's extend wrapper around [tg.ChosenInlineResult].
-type ChosenInlineResultUpdate struct {
-	*tg.ChosenInlineResult
-	BaseUpdate
-}
-
-// RemovedChatBoostUpdate it's extend wrapper around [tg.ChatBoostRemoved].
-type RemovedChatBoostUpdate struct {
-	*tg.ChatBoostRemoved
-	BaseUpdate
-}
-
-// InlineQueryUpdate it's extend wrapper around [tg.InlineQuery].
-type InlineQueryUpdate struct {
-	*tg.InlineQuery
-	BaseUpdate
-}
-
-// ShippingQueryUpdate it's extend wrapper around [tg.ShippingQuery].
-type ShippingQueryUpdate struct {
-	*tg.ShippingQuery
-	BaseUpdate
-}
-
-// PurchasedPaidMediaUpdate it's extend wrapper around [tg.PaidMediaPurchased].
-type PurchasedPaidMediaUpdate struct {
-	*tg.PaidMediaPurchased
-	BaseUpdate
-}
-
-// ChatJoinRequestUpdate it's extend wrapper around [tg.ChatJoinRequest].
-type ChatJoinRequestUpdate struct {
-	*tg.ChatJoinRequest
-	BaseUpdate
-}
-
 // PollAnswerUpdate it's extend wrapper around [tg.PollAnswer].
 type PollAnswerUpdate struct {
 	*tg.PollAnswer
+	BaseUpdate
+}
+
+// PollUpdate it's extend wrapper around [tg.Poll].
+type PollUpdate struct {
+	*tg.Poll
 	BaseUpdate
 }
 
@@ -92,6 +62,48 @@ type BusinessConnectionUpdate struct {
 	BaseUpdate
 }
 
+// InlineQueryUpdate it's extend wrapper around [tg.InlineQuery].
+type InlineQueryUpdate struct {
+	*tg.InlineQuery
+	BaseUpdate
+}
+
+// CallbackQueryUpdate it's extend wrapper around [tg.CallbackQuery].
+type CallbackQueryUpdate struct {
+	*tg.CallbackQuery
+	BaseUpdate
+}
+
+// RemovedChatBoostUpdate it's extend wrapper around [tg.ChatBoostRemoved].
+type RemovedChatBoostUpdate struct {
+	*tg.ChatBoostRemoved
+	BaseUpdate
+}
+
+// ChosenInlineResultUpdate it's extend wrapper around [tg.ChosenInlineResult].
+type ChosenInlineResultUpdate struct {
+	*tg.ChosenInlineResult
+	BaseUpdate
+}
+
+// ChatJoinRequestUpdate it's extend wrapper around [tg.ChatJoinRequest].
+type ChatJoinRequestUpdate struct {
+	*tg.ChatJoinRequest
+	BaseUpdate
+}
+
+// PurchasedPaidMediaUpdate it's extend wrapper around [tg.PaidMediaPurchased].
+type PurchasedPaidMediaUpdate struct {
+	*tg.PaidMediaPurchased
+	BaseUpdate
+}
+
+// DeletedBusinessMessagesUpdate it's extend wrapper around [tg.BusinessMessagesDeleted].
+type DeletedBusinessMessagesUpdate struct {
+	*tg.BusinessMessagesDeleted
+	BaseUpdate
+}
+
 // MessageReactionUpdate it's extend wrapper around [tg.MessageReactionUpdated].
 type MessageReactionUpdate struct {
 	*tg.MessageReactionUpdated
@@ -101,17 +113,5 @@ type MessageReactionUpdate struct {
 // MessageReactionCountUpdate it's extend wrapper around [tg.MessageReactionCountUpdated].
 type MessageReactionCountUpdate struct {
 	*tg.MessageReactionCountUpdated
-	BaseUpdate
-}
-
-// PreCheckoutQueryUpdate it's extend wrapper around [tg.PreCheckoutQuery].
-type PreCheckoutQueryUpdate struct {
-	*tg.PreCheckoutQuery
-	BaseUpdate
-}
-
-// PollUpdate it's extend wrapper around [tg.Poll].
-type PollUpdate struct {
-	*tg.Poll
 	BaseUpdate
 }

--- a/tgb/update_test.go
+++ b/tgb/update_test.go
@@ -322,7 +322,7 @@ func TestMessageUpdateHelpers(t *testing.T) {
 			Name: "EditReplyMarkup",
 			Request: msg.EditReplyMarkup(tg.NewInlineKeyboardMarkup(
 				tg.NewButtonRow(
-					tg.NewInlineKeyboardButtonCallback("1", "1"),
+					tg.NewInlineKeyboardButtonCallbackData("1", "1"),
 				),
 			)).Request(),
 			ExceptedMethod: "editMessageReplyMarkup",

--- a/types_gen.go
+++ b/types_gen.go
@@ -8502,7 +8502,7 @@ func (v *Message) Type() MessageType {
 	}
 }
 
-// NewInlineKeyboardButtonURL creates a InlineKeyboardButton with URL.
+// NewInlineKeyboardButtonURL creates InlineKeyboardButton with URL.
 func NewInlineKeyboardButtonURL(text string, url string) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text: text,
@@ -8510,7 +8510,7 @@ func NewInlineKeyboardButtonURL(text string, url string) InlineKeyboardButton {
 	}
 }
 
-// NewInlineKeyboardButtonCallbackData creates a InlineKeyboardButton with CallbackData.
+// NewInlineKeyboardButtonCallbackData creates InlineKeyboardButton with CallbackData.
 func NewInlineKeyboardButtonCallbackData(text string, callbackData string) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:         text,
@@ -8518,7 +8518,7 @@ func NewInlineKeyboardButtonCallbackData(text string, callbackData string) Inlin
 	}
 }
 
-// NewInlineKeyboardButtonWebApp creates a InlineKeyboardButton with WebApp.
+// NewInlineKeyboardButtonWebApp creates InlineKeyboardButton with WebApp.
 func NewInlineKeyboardButtonWebApp(text string, webApp WebAppInfo) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:   text,
@@ -8526,7 +8526,7 @@ func NewInlineKeyboardButtonWebApp(text string, webApp WebAppInfo) InlineKeyboar
 	}
 }
 
-// NewInlineKeyboardButtonLoginURL creates a InlineKeyboardButton with LoginURL.
+// NewInlineKeyboardButtonLoginURL creates InlineKeyboardButton with LoginURL.
 func NewInlineKeyboardButtonLoginURL(text string, loginURL LoginURL) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:     text,
@@ -8534,7 +8534,7 @@ func NewInlineKeyboardButtonLoginURL(text string, loginURL LoginURL) InlineKeybo
 	}
 }
 
-// NewInlineKeyboardButtonSwitchInlineQuery creates a InlineKeyboardButton with SwitchInlineQuery.
+// NewInlineKeyboardButtonSwitchInlineQuery creates InlineKeyboardButton with SwitchInlineQuery.
 func NewInlineKeyboardButtonSwitchInlineQuery(text string, switchInlineQuery string) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:              text,
@@ -8542,7 +8542,7 @@ func NewInlineKeyboardButtonSwitchInlineQuery(text string, switchInlineQuery str
 	}
 }
 
-// NewInlineKeyboardButtonSwitchInlineQueryCurrentChat creates a InlineKeyboardButton with SwitchInlineQueryCurrentChat.
+// NewInlineKeyboardButtonSwitchInlineQueryCurrentChat creates InlineKeyboardButton with SwitchInlineQueryCurrentChat.
 func NewInlineKeyboardButtonSwitchInlineQueryCurrentChat(text string, switchInlineQueryCurrentChat string) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:                         text,
@@ -8550,7 +8550,7 @@ func NewInlineKeyboardButtonSwitchInlineQueryCurrentChat(text string, switchInli
 	}
 }
 
-// NewInlineKeyboardButtonSwitchInlineQueryChosenChat creates a InlineKeyboardButton with SwitchInlineQueryChosenChat.
+// NewInlineKeyboardButtonSwitchInlineQueryChosenChat creates InlineKeyboardButton with SwitchInlineQueryChosenChat.
 func NewInlineKeyboardButtonSwitchInlineQueryChosenChat(text string, switchInlineQueryChosenChat SwitchInlineQueryChosenChat) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:                        text,
@@ -8558,7 +8558,7 @@ func NewInlineKeyboardButtonSwitchInlineQueryChosenChat(text string, switchInlin
 	}
 }
 
-// NewInlineKeyboardButtonCopyText creates a InlineKeyboardButton with CopyText.
+// NewInlineKeyboardButtonCopyText creates InlineKeyboardButton with CopyText.
 func NewInlineKeyboardButtonCopyText(text string, copyText CopyTextButton) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:     text,
@@ -8566,7 +8566,7 @@ func NewInlineKeyboardButtonCopyText(text string, copyText CopyTextButton) Inlin
 	}
 }
 
-// NewInlineKeyboardButtonCallbackGame creates a InlineKeyboardButton with CallbackGame.
+// NewInlineKeyboardButtonCallbackGame creates InlineKeyboardButton with CallbackGame.
 func NewInlineKeyboardButtonCallbackGame(text string) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text:         text,
@@ -8574,7 +8574,7 @@ func NewInlineKeyboardButtonCallbackGame(text string) InlineKeyboardButton {
 	}
 }
 
-// NewInlineKeyboardButtonPay creates a InlineKeyboardButton with Pay.
+// NewInlineKeyboardButtonPay creates InlineKeyboardButton with Pay.
 func NewInlineKeyboardButtonPay(text string) InlineKeyboardButton {
 	return InlineKeyboardButton{
 		Text: text,
@@ -8582,14 +8582,14 @@ func NewInlineKeyboardButtonPay(text string) InlineKeyboardButton {
 	}
 }
 
-// NewKeyboardButton creates a KeyboardButton.
+// NewKeyboardButton creates KeyboardButton.
 func NewKeyboardButton(text string) KeyboardButton {
 	return KeyboardButton{
 		Text: text,
 	}
 }
 
-// NewKeyboardButtonRequestUsers creates a KeyboardButton with RequestUsers.
+// NewKeyboardButtonRequestUsers creates KeyboardButton with RequestUsers.
 func NewKeyboardButtonRequestUsers(text string, requestUsers KeyboardButtonRequestUsers) KeyboardButton {
 	return KeyboardButton{
 		Text:         text,
@@ -8597,7 +8597,7 @@ func NewKeyboardButtonRequestUsers(text string, requestUsers KeyboardButtonReque
 	}
 }
 
-// NewKeyboardButtonRequestChat creates a KeyboardButton with RequestChat.
+// NewKeyboardButtonRequestChat creates KeyboardButton with RequestChat.
 func NewKeyboardButtonRequestChat(text string, requestChat KeyboardButtonRequestChat) KeyboardButton {
 	return KeyboardButton{
 		Text:        text,
@@ -8605,7 +8605,7 @@ func NewKeyboardButtonRequestChat(text string, requestChat KeyboardButtonRequest
 	}
 }
 
-// NewKeyboardButtonRequestContact creates a KeyboardButton with RequestContact.
+// NewKeyboardButtonRequestContact creates KeyboardButton with RequestContact.
 func NewKeyboardButtonRequestContact(text string) KeyboardButton {
 	return KeyboardButton{
 		Text:           text,
@@ -8613,7 +8613,7 @@ func NewKeyboardButtonRequestContact(text string) KeyboardButton {
 	}
 }
 
-// NewKeyboardButtonRequestLocation creates a KeyboardButton with RequestLocation.
+// NewKeyboardButtonRequestLocation creates KeyboardButton with RequestLocation.
 func NewKeyboardButtonRequestLocation(text string) KeyboardButton {
 	return KeyboardButton{
 		Text:            text,
@@ -8621,7 +8621,7 @@ func NewKeyboardButtonRequestLocation(text string) KeyboardButton {
 	}
 }
 
-// NewKeyboardButtonRequestPoll creates a KeyboardButton with RequestPoll.
+// NewKeyboardButtonRequestPoll creates KeyboardButton with RequestPoll.
 func NewKeyboardButtonRequestPoll(text string, requestPoll KeyboardButtonPollType) KeyboardButton {
 	return KeyboardButton{
 		Text:        text,
@@ -8629,7 +8629,7 @@ func NewKeyboardButtonRequestPoll(text string, requestPoll KeyboardButtonPollTyp
 	}
 }
 
-// NewKeyboardButtonWebApp creates a KeyboardButton with WebApp.
+// NewKeyboardButtonWebApp creates KeyboardButton with WebApp.
 func NewKeyboardButtonWebApp(text string, webApp WebAppInfo) KeyboardButton {
 	return KeyboardButton{
 		Text:   text,
@@ -8637,7 +8637,7 @@ func NewKeyboardButtonWebApp(text string, webApp WebAppInfo) KeyboardButton {
 	}
 }
 
-// NewInlineQueryResultsButtonWebApp creates a InlineQueryResultsButton with WebApp.
+// NewInlineQueryResultsButtonWebApp creates InlineQueryResultsButton with WebApp.
 func NewInlineQueryResultsButtonWebApp(text string, webApp WebAppInfo) InlineQueryResultsButton {
 	return InlineQueryResultsButton{
 		Text:   text,
@@ -8645,7 +8645,7 @@ func NewInlineQueryResultsButtonWebApp(text string, webApp WebAppInfo) InlineQue
 	}
 }
 
-// NewInlineQueryResultsButtonStartParameter creates a InlineQueryResultsButton with StartParameter.
+// NewInlineQueryResultsButtonStartParameter creates InlineQueryResultsButton with StartParameter.
 func NewInlineQueryResultsButtonStartParameter(text string, startParameter string) InlineQueryResultsButton {
 	return InlineQueryResultsButton{
 		Text:           text,

--- a/types_gen.go
+++ b/types_gen.go
@@ -8501,3 +8501,154 @@ func (v *Message) Type() MessageType {
 		return MessageTypeUnknown
 	}
 }
+
+// NewInlineKeyboardButtonURL creates a InlineKeyboardButton with URL.
+func NewInlineKeyboardButtonURL(text string, url string) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text: text,
+		URL:  url,
+	}
+}
+
+// NewInlineKeyboardButtonCallbackData creates a InlineKeyboardButton with CallbackData.
+func NewInlineKeyboardButtonCallbackData(text string, callbackData string) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:         text,
+		CallbackData: callbackData,
+	}
+}
+
+// NewInlineKeyboardButtonWebApp creates a InlineKeyboardButton with WebApp.
+func NewInlineKeyboardButtonWebApp(text string, webApp WebAppInfo) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:   text,
+		WebApp: &webApp,
+	}
+}
+
+// NewInlineKeyboardButtonLoginURL creates a InlineKeyboardButton with LoginURL.
+func NewInlineKeyboardButtonLoginURL(text string, loginURL LoginURL) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:     text,
+		LoginURL: &loginURL,
+	}
+}
+
+// NewInlineKeyboardButtonSwitchInlineQuery creates a InlineKeyboardButton with SwitchInlineQuery.
+func NewInlineKeyboardButtonSwitchInlineQuery(text string, switchInlineQuery string) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:              text,
+		SwitchInlineQuery: switchInlineQuery,
+	}
+}
+
+// NewInlineKeyboardButtonSwitchInlineQueryCurrentChat creates a InlineKeyboardButton with SwitchInlineQueryCurrentChat.
+func NewInlineKeyboardButtonSwitchInlineQueryCurrentChat(text string, switchInlineQueryCurrentChat string) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:                         text,
+		SwitchInlineQueryCurrentChat: switchInlineQueryCurrentChat,
+	}
+}
+
+// NewInlineKeyboardButtonSwitchInlineQueryChosenChat creates a InlineKeyboardButton with SwitchInlineQueryChosenChat.
+func NewInlineKeyboardButtonSwitchInlineQueryChosenChat(text string, switchInlineQueryChosenChat SwitchInlineQueryChosenChat) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:                        text,
+		SwitchInlineQueryChosenChat: &switchInlineQueryChosenChat,
+	}
+}
+
+// NewInlineKeyboardButtonCopyText creates a InlineKeyboardButton with CopyText.
+func NewInlineKeyboardButtonCopyText(text string, copyText CopyTextButton) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:     text,
+		CopyText: &copyText,
+	}
+}
+
+// NewInlineKeyboardButtonCallbackGame creates a InlineKeyboardButton with CallbackGame.
+func NewInlineKeyboardButtonCallbackGame(text string) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text:         text,
+		CallbackGame: &CallbackGame{},
+	}
+}
+
+// NewInlineKeyboardButtonPay creates a InlineKeyboardButton with Pay.
+func NewInlineKeyboardButtonPay(text string) InlineKeyboardButton {
+	return InlineKeyboardButton{
+		Text: text,
+		Pay:  true,
+	}
+}
+
+// NewKeyboardButton creates a KeyboardButton.
+func NewKeyboardButton(text string) KeyboardButton {
+	return KeyboardButton{
+		Text: text,
+	}
+}
+
+// NewKeyboardButtonRequestUsers creates a KeyboardButton with RequestUsers.
+func NewKeyboardButtonRequestUsers(text string, requestUsers KeyboardButtonRequestUsers) KeyboardButton {
+	return KeyboardButton{
+		Text:         text,
+		RequestUsers: &requestUsers,
+	}
+}
+
+// NewKeyboardButtonRequestChat creates a KeyboardButton with RequestChat.
+func NewKeyboardButtonRequestChat(text string, requestChat KeyboardButtonRequestChat) KeyboardButton {
+	return KeyboardButton{
+		Text:        text,
+		RequestChat: &requestChat,
+	}
+}
+
+// NewKeyboardButtonRequestContact creates a KeyboardButton with RequestContact.
+func NewKeyboardButtonRequestContact(text string) KeyboardButton {
+	return KeyboardButton{
+		Text:           text,
+		RequestContact: true,
+	}
+}
+
+// NewKeyboardButtonRequestLocation creates a KeyboardButton with RequestLocation.
+func NewKeyboardButtonRequestLocation(text string) KeyboardButton {
+	return KeyboardButton{
+		Text:            text,
+		RequestLocation: true,
+	}
+}
+
+// NewKeyboardButtonRequestPoll creates a KeyboardButton with RequestPoll.
+func NewKeyboardButtonRequestPoll(text string, requestPoll KeyboardButtonPollType) KeyboardButton {
+	return KeyboardButton{
+		Text:        text,
+		RequestPoll: &requestPoll,
+	}
+}
+
+// NewKeyboardButtonWebApp creates a KeyboardButton with WebApp.
+func NewKeyboardButtonWebApp(text string, webApp WebAppInfo) KeyboardButton {
+	return KeyboardButton{
+		Text:   text,
+		WebApp: &webApp,
+	}
+}
+
+// NewInlineQueryResultsButtonWebApp creates a InlineQueryResultsButton with WebApp.
+func NewInlineQueryResultsButtonWebApp(text string, webApp WebAppInfo) InlineQueryResultsButton {
+	return InlineQueryResultsButton{
+		Text:   text,
+		WebApp: &webApp,
+	}
+}
+
+// NewInlineQueryResultsButtonStartParameter creates a InlineQueryResultsButton with StartParameter.
+func NewInlineQueryResultsButtonStartParameter(text string, startParameter string) InlineQueryResultsButton {
+	return InlineQueryResultsButton{
+		Text:           text,
+		StartParameter: startParameter,
+	}
+}

--- a/types_gen_ext.go
+++ b/types_gen_ext.go
@@ -171,80 +171,8 @@ func (markup InlineKeyboardMarkup) Ptr() *InlineKeyboardMarkup {
 	return &markup
 }
 
-// NewInlineButtonURL create inline button
-// with http(s):// or tg:// URL to be opened when the button is pressed.
-func NewInlineKeyboardButtonURL(text, url string) InlineKeyboardButton {
-	return InlineKeyboardButton{
-		Text: text,
-		URL:  url,
-	}
-}
-
-// NewInlineKeyboardButtonCallback creates a new InlineKeyboardButton with specified callback data.
-// Query should have length 1-64 bytes.
-func NewInlineKeyboardButtonCallback(text, query string) InlineKeyboardButton {
-	return InlineKeyboardButton{
-		Text:         text,
-		CallbackData: query,
-	}
-}
-
 type CallbackDataEncoder[T any] interface {
 	Encode(data T) (string, error)
-}
-
-// NewInlineKeyboardButtonWebApp creates a button that open a web app.
-func NewInlineKeyboardButtonWebApp(text string, webApp WebAppInfo) InlineKeyboardButton {
-	return InlineKeyboardButton{
-		Text:   text,
-		WebApp: &webApp,
-	}
-}
-
-// InlineKeyboardMarkup represents button that open web page with auth data.
-func NewInlineKeyboardButtonLoginURL(text string, loginURL LoginURL) InlineKeyboardButton {
-	return InlineKeyboardButton{
-		Text:     text,
-		LoginURL: &loginURL,
-	}
-}
-
-// NewInlineKeyboardButtonSwitchInlineQuery represents button that
-//
-//	will prompt the user to select one of their chats,
-//
-// open that chat and insert the bot's username and the specified inline query in the input field.
-func NewInlineKeyboardButtonSwitchInlineQuery(text, query string) InlineKeyboardButton {
-	return InlineKeyboardButton{
-		Text:              text,
-		SwitchInlineQuery: query,
-	}
-}
-
-// NewInlineKeyboardButtonSwitchInlineQueryCurrentChat represents button that
-// will insert the bot's username and the specified inline query in the current chat's input field
-func NewInlineKeyboardButtonSwitchInlineQueryCurrentChat(text, query string) InlineKeyboardButton {
-	return InlineKeyboardButton{
-		Text:                         text,
-		SwitchInlineQueryCurrentChat: query,
-	}
-}
-
-// NewInlineKeyboardButtonCallbackGame represents the button which open a game.
-func NewInlineKeyboardButtonCallbackGame(text string) InlineKeyboardButton {
-	return InlineKeyboardButton{
-		Text:         text,
-		CallbackGame: &CallbackGame{},
-	}
-}
-
-// NewInlineKeyboardButtonPay represents a Pay button.
-// NOTE: This type of button must always be the first button in the first row and can only be used in invoice messages
-func NewInlineKeyboardButtonPay(text string) InlineKeyboardButton {
-	return InlineKeyboardButton{
-		Text: text,
-		Pay:  true,
-	}
 }
 
 func (markup InlineKeyboardMarkup) isReplyMarkup() {}
@@ -286,66 +214,6 @@ func (markup *ReplyKeyboardMarkup) WithInputFieldPlaceholder(placeholder string)
 func (markup *ReplyKeyboardMarkup) WithSelective() *ReplyKeyboardMarkup {
 	markup.Selective = true
 	return markup
-}
-
-// NewKeyboardButton creates a plain reply keyboard button.
-func NewKeyboardButton(text string) KeyboardButton {
-	return KeyboardButton{
-		Text: text,
-	}
-}
-
-// NewKeyboardButtonRequestContact creates a reply keyboard button that request a contact from user.
-// Available in private chats only.
-func NewKeyboardButtonRequestContact(text string) KeyboardButton {
-	return KeyboardButton{
-		Text:           text,
-		RequestContact: true,
-	}
-}
-
-// NewKeyboardButtonRequestLocation creates a reply keyboard button that request a location from user.
-// Available in private chats only.
-func NewKeyboardButtonRequestLocation(text string) KeyboardButton {
-	return KeyboardButton{
-		Text:            text,
-		RequestLocation: true,
-	}
-}
-
-// NewKeyboardButtonRequestPoll creates a reply keyboard button that request a poll from user.
-// Available in private chats only.
-func NewKeyboardButtonRequestPoll(text string, poll KeyboardButtonPollType) KeyboardButton {
-	return KeyboardButton{
-		Text:        text,
-		RequestPoll: &poll,
-	}
-}
-
-// NewKeyboardButtonWebApp create a reply keyboard button that open a web app.
-func NewKeyboardButtonWebApp(text string, webApp WebAppInfo) KeyboardButton {
-	return KeyboardButton{
-		Text:   text,
-		WebApp: &webApp,
-	}
-}
-
-// NewKeyboardButtonRequestUsers creates a reply keyboard button that request a user from user.
-// Available in private chats only.
-func NewKeyboardButtonRequestUsers(text string, config KeyboardButtonRequestUsers) KeyboardButton {
-	return KeyboardButton{
-		Text:         text,
-		RequestUsers: &config,
-	}
-}
-
-// NewKeyboardButtonRequestChats creates a reply keyboard button that request a chat from user.
-// Available in private chats only.
-func NewKeyboardButtonRequestChat(text string, config KeyboardButtonRequestChat) KeyboardButton {
-	return KeyboardButton{
-		Text:        text,
-		RequestChat: &config,
-	}
 }
 
 func (markup ReplyKeyboardMarkup) isReplyMarkup() {}

--- a/types_gen_ext_test.go
+++ b/types_gen_ext_test.go
@@ -166,7 +166,7 @@ func TestInlineReplyMarkup(t *testing.T) {
 	actual := NewInlineKeyboardMarkup(
 		NewButtonRow(
 			NewInlineKeyboardButtonURL("text", "https://google.com"),
-			NewInlineKeyboardButtonCallback("text", "data"),
+			NewInlineKeyboardButtonCallbackData("text", "data"),
 			NewInlineKeyboardButtonWebApp("text", WebAppInfo{}),
 			NewInlineKeyboardButtonLoginURL("text", LoginURL{
 				URL: "https://google.com",
@@ -260,9 +260,9 @@ func TestForceReplay(t *testing.T) {
 
 func TestNewButtonLayout(t *testing.T) {
 	keyboard := NewButtonLayout(1,
-		NewInlineKeyboardButtonCallback("1", "1"),
-		NewInlineKeyboardButtonCallback("2", "2"),
-		NewInlineKeyboardButtonCallback("3", "3"),
+		NewInlineKeyboardButtonCallbackData("1", "1"),
+		NewInlineKeyboardButtonCallbackData("2", "2"),
+		NewInlineKeyboardButtonCallbackData("3", "3"),
 	).Keyboard()
 
 	assert.Equal(t, [][]InlineKeyboardButton{
@@ -395,9 +395,9 @@ func TestButtonLayout_Insert(t *testing.T) {
 
 func TestNewButtonColumn(t *testing.T) {
 	keyboard := NewButtonColumn(
-		NewInlineKeyboardButtonCallback("1", "1"),
-		NewInlineKeyboardButtonCallback("2", "2"),
-		NewInlineKeyboardButtonCallback("3", "3"),
+		NewInlineKeyboardButtonCallbackData("1", "1"),
+		NewInlineKeyboardButtonCallbackData("2", "2"),
+		NewInlineKeyboardButtonCallbackData("3", "3"),
 	)
 
 	assert.Equal(t, [][]InlineKeyboardButton{

--- a/types_gen_test.go
+++ b/types_gen_test.go
@@ -1,0 +1,151 @@
+package tg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInlineKeyboardButtonConstructors(t *testing.T) {
+	for _, test := range []struct {
+		Name   string
+		Button InlineKeyboardButton
+		Want   InlineKeyboardButton
+	}{
+		{
+			Name:   "URL",
+			Button: NewInlineKeyboardButtonURL("text", "https://example.com"),
+			Want:   InlineKeyboardButton{Text: "text", URL: "https://example.com"},
+		},
+		{
+			Name:   "CallbackData",
+			Button: NewInlineKeyboardButtonCallbackData("text", "data"),
+			Want:   InlineKeyboardButton{Text: "text", CallbackData: "data"},
+		},
+		{
+			Name:   "WebApp",
+			Button: NewInlineKeyboardButtonWebApp("text", WebAppInfo{URL: "https://example.com/app"}),
+			Want:   InlineKeyboardButton{Text: "text", WebApp: &WebAppInfo{URL: "https://example.com/app"}},
+		},
+		{
+			Name: "LoginURL",
+			Button: NewInlineKeyboardButtonLoginURL("text", LoginURL{
+				URL:                "https://example.com/login",
+				ForwardText:        "forward",
+				BotUsername:        "bot",
+				RequestWriteAccess: true,
+			}),
+			Want: InlineKeyboardButton{Text: "text", LoginURL: &LoginURL{
+				URL:                "https://example.com/login",
+				ForwardText:        "forward",
+				BotUsername:        "bot",
+				RequestWriteAccess: true,
+			}},
+		},
+		{
+			Name:   "SwitchInlineQuery",
+			Button: NewInlineKeyboardButtonSwitchInlineQuery("text", "query"),
+			Want:   InlineKeyboardButton{Text: "text", SwitchInlineQuery: "query"},
+		},
+		{
+			Name:   "SwitchInlineQueryCurrentChat",
+			Button: NewInlineKeyboardButtonSwitchInlineQueryCurrentChat("text", "query"),
+			Want:   InlineKeyboardButton{Text: "text", SwitchInlineQueryCurrentChat: "query"},
+		},
+		{
+			Name:   "SwitchInlineQueryChosenChat",
+			Button: NewInlineKeyboardButtonSwitchInlineQueryChosenChat("text", SwitchInlineQueryChosenChat{Query: "query", AllowUserChats: true}),
+			Want:   InlineKeyboardButton{Text: "text", SwitchInlineQueryChosenChat: &SwitchInlineQueryChosenChat{Query: "query", AllowUserChats: true}},
+		},
+		{
+			Name:   "CopyText",
+			Button: NewInlineKeyboardButtonCopyText("text", CopyTextButton{Text: "copy this"}),
+			Want:   InlineKeyboardButton{Text: "text", CopyText: &CopyTextButton{Text: "copy this"}},
+		},
+		{
+			Name:   "CallbackGame",
+			Button: NewInlineKeyboardButtonCallbackGame("text"),
+			Want:   InlineKeyboardButton{Text: "text", CallbackGame: &CallbackGame{}},
+		},
+		{
+			Name:   "Pay",
+			Button: NewInlineKeyboardButtonPay("text"),
+			Want:   InlineKeyboardButton{Text: "text", Pay: true},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert.Equal(t, test.Want, test.Button)
+		})
+	}
+}
+
+func TestKeyboardButtonConstructors(t *testing.T) {
+	for _, test := range []struct {
+		Name   string
+		Button KeyboardButton
+		Want   KeyboardButton
+	}{
+		{
+			Name:   "Base",
+			Button: NewKeyboardButton("text"),
+			Want:   KeyboardButton{Text: "text"},
+		},
+		{
+			Name:   "RequestUsers",
+			Button: NewKeyboardButtonRequestUsers("text", KeyboardButtonRequestUsers{RequestID: 1, UserIsBot: true}),
+			Want:   KeyboardButton{Text: "text", RequestUsers: &KeyboardButtonRequestUsers{RequestID: 1, UserIsBot: true}},
+		},
+		{
+			Name:   "RequestChat",
+			Button: NewKeyboardButtonRequestChat("text", KeyboardButtonRequestChat{RequestID: 2, ChatIsChannel: true}),
+			Want:   KeyboardButton{Text: "text", RequestChat: &KeyboardButtonRequestChat{RequestID: 2, ChatIsChannel: true}},
+		},
+		{
+			Name:   "RequestContact",
+			Button: NewKeyboardButtonRequestContact("text"),
+			Want:   KeyboardButton{Text: "text", RequestContact: true},
+		},
+		{
+			Name:   "RequestLocation",
+			Button: NewKeyboardButtonRequestLocation("text"),
+			Want:   KeyboardButton{Text: "text", RequestLocation: true},
+		},
+		{
+			Name:   "RequestPoll",
+			Button: NewKeyboardButtonRequestPoll("text", KeyboardButtonPollType{Type: "quiz"}),
+			Want:   KeyboardButton{Text: "text", RequestPoll: &KeyboardButtonPollType{Type: "quiz"}},
+		},
+		{
+			Name:   "WebApp",
+			Button: NewKeyboardButtonWebApp("text", WebAppInfo{URL: "https://example.com/app"}),
+			Want:   KeyboardButton{Text: "text", WebApp: &WebAppInfo{URL: "https://example.com/app"}},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert.Equal(t, test.Want, test.Button)
+		})
+	}
+}
+
+func TestInlineQueryResultsButtonConstructors(t *testing.T) {
+	for _, test := range []struct {
+		Name   string
+		Button InlineQueryResultsButton
+		Want   InlineQueryResultsButton
+	}{
+		{
+			Name:   "StartParameter",
+			Button: NewInlineQueryResultsButtonStartParameter("text", "start-param"),
+			Want:   InlineQueryResultsButton{Text: "text", StartParameter: "start-param"},
+		},
+		{
+			Name:   "WebApp",
+			Button: NewInlineQueryResultsButtonWebApp("text", WebAppInfo{URL: "https://example.com/app"}),
+			Want:   InlineQueryResultsButton{Text: "text", WebApp: &WebAppInfo{URL: "https://example.com/app"}},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert.Equal(t, test.Want, test.Button)
+		})
+	}
+}


### PR DESCRIPTION
Add code generation for variant constructors (InlineKeyboardButton, KeyboardButton, InlineQueryResultsButton) instead of manual definitions.

- Add VariantConstructorDef to config with base_field, include_base, exclude, and defaults options
- Generate constructors from optional fields automatically
- Accept values for pointer types in constructors (take address inside)
- Remove manual constructors from types_gen_ext.go

BREAKING CHANGE: NewInlineKeyboardButtonCallback renamed to NewInlineKeyboardButtonCallbackData

## Summary by Sourcery

Introduce generator-backed variant constructors for Telegram button types and align callback-related naming across code, tests, and examples.

New Features:
- Add generated constructor functions for InlineKeyboardButton, KeyboardButton, and InlineQueryResultsButton variants based on the Telegram Bot API fields.

Enhancements:
- Extend the type generation pipeline with configurable variant constructor support, including base-field selection, exclusions, and default values.
- Refine typed update wrapper and handler definitions to cover additional update types and keep them consistently ordered.

Documentation:
- Document the breaking rename of the callback button constructor via the new InlineKeyboardButtonCallbackData API in usage sites.

Tests:
- Update button-related tests and examples to use the new InlineKeyboardButtonCallbackData constructor and validate the generated helpers.