### PR TITLE
chore: update Telegram Bot API to v9.4 (71c87c28d105)

### DIFF
--- a/_spec/api.html
+++ b/_spec/api.html
@@ -1455,7 +1455,7 @@ To learn how to create…">
 <tr>
 <td>reply_markup</td>
 <td><a href="#inlinekeyboardmarkup">InlineKeyboardMarkup</a></td>
-<td><em>Optional</em>. Inline keyboard attached to the message. <code>login_url</code> buttons are represented as ordinary <code>url</code> buttons.</td>
+<td><em>Optional</em>. <a href="/bots/features#inline-keyboards">Inline keyboard</a> attached to the message. <code>login_url</code> buttons are represented as ordinary <code>url</code> buttons.</td>
 </tr>
 </tbody>
 </table>
@@ -10239,7 +10239,7 @@ pre-formatted fixed-width code block written in the Python programming language
 <td>reply_markup</td>
 <td><a href="#inlinekeyboardmarkup">InlineKeyboardMarkup</a></td>
 <td>Optional</td>
-<td>A JSON-serialized object for an inline keyboard</td>
+<td>A JSON-serialized object for an <a href="/bots/features#inline-keyboards">inline keyboard</a></td>
 </tr>
 </tbody>
 </table>
@@ -13633,7 +13633,7 @@ pre-formatted fixed-width code block written in the Python programming language
 <td>reply_markup</td>
 <td><a href="#inlinekeyboardmarkup">InlineKeyboardMarkup</a></td>
 <td>Optional</td>
-<td>A JSON-serialized object for the new inline keyboard for the message</td>
+<td>A JSON-serialized object for the new <a href="/bots/features#inline-keyboards">inline keyboard</a> for the message</td>
 </tr>
 </tbody>
 </table>
@@ -15309,7 +15309,7 @@ pre-formatted fixed-width code block written in the Python programming language
 <tr>
 <td>reply_markup</td>
 <td><a href="#inlinekeyboardmarkup">InlineKeyboardMarkup</a></td>
-<td><em>Optional</em>. Inline keyboard attached to the message</td>
+<td><em>Optional</em>. <a href="/bots/features#inline-keyboards">Inline keyboard</a> attached to the message</td>
 </tr>
 <tr>
 <td>input_message_content</td>
@@ -18524,7 +18524,7 @@ pre-formatted fixed-width code block written in the Python programming language
 </tbody>
 </table>
 <hr>
-<p>And that&#39;s about all we&#39;ve got for now.<br>If you&#39;ve got any questions, please check out our <a href="/bots/faq"><strong>Bot FAQ »</strong></a><br>-</p>
+<p>And that&#39;s about all we&#39;ve got for now.<br>If you&#39;ve got any questions, please check out our <a href="/bots/faq"><strong>Bot FAQ »</strong></a></p>
 </div>
   
 </div>

--- a/_spec/api.yaml
+++ b/_spec/api.yaml
@@ -1,6 +1,6 @@
 version: "9.4"
 release_date: February 9, 2026
-hash: 17154abd0187
+hash: 71c87c28d105
 types:
   - name: Update
     description: This [object](https://core.telegram.org/bots/api#available-types) represents an incoming update. At most one of the optional parameters can be present in any given update.
@@ -1080,7 +1080,7 @@ types:
         type:
           types: [{type: InlineKeyboardMarkup, ref: inlinekeyboardmarkup}]
         optional: true
-        description: Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
+        description: Optional. [Inline keyboard](https://core.telegram.org/bots/features#inline-keyboards) attached to the message. login_url buttons are represented as ordinary url buttons.
   - name: MessageId
     description: This object represents a unique message identifier.
     fields:
@@ -6360,7 +6360,7 @@ types:
         type:
           types: [{type: InlineKeyboardMarkup, ref: inlinekeyboardmarkup}]
         optional: true
-        description: Optional. Inline keyboard attached to the message
+        description: Optional. [Inline keyboard](https://core.telegram.org/bots/features#inline-keyboards) attached to the message
       - name: input_message_content
         type:
           types: [{type: InputMessageContent, ref: inputmessagecontent}]
@@ -8169,7 +8169,7 @@ types:
   - name: GameHighScore
     description: |-
       This object represents one row of the high scores table for a game.
-      And that's about all we've got for now. If you've got any questions, please check out our [Bot FAQ »](https://core.telegram.org/bots/faq) -
+      And that's about all we've got for now. If you've got any questions, please check out our [Bot FAQ »](https://core.telegram.org/bots/faq)
     fields:
       - name: position
         type:
@@ -9705,7 +9705,7 @@ methods:
       - name: reply_markup
         type:
           types: [{type: InlineKeyboardMarkup, ref: inlinekeyboardmarkup}]
-        description: A JSON-serialized object for an inline keyboard
+        description: A JSON-serialized object for an [inline keyboard](https://core.telegram.org/bots/features#inline-keyboards)
     returns:
       types: [{type: Message, ref: message}]
   - name: sendDice
@@ -11928,7 +11928,7 @@ methods:
       - name: reply_markup
         type:
           types: [{type: InlineKeyboardMarkup, ref: inlinekeyboardmarkup}]
-        description: A JSON-serialized object for the new inline keyboard for the message
+        description: A JSON-serialized object for the new [inline keyboard](https://core.telegram.org/bots/features#inline-keyboards) for the message
     returns:
       types: [{type: Message, ref: message}]
   - name: editMessageReplyMarkup

--- a/methods_gen.go
+++ b/methods_gen.go
@@ -4,7 +4,7 @@ package tg
 //
 // Telegram Bot API version: 9.4
 // Release date: February 9, 2026
-// Spec hash: 17154abd0187
+// Spec hash: 71c87c28d105
 
 // GetUpdatesCall represents a call to the [getUpdates] method.
 // Use this method to receive incoming updates using long polling ([wiki]). Returns an Array of [Update] objects.

--- a/tgb/handler_gen.go
+++ b/tgb/handler_gen.go
@@ -4,7 +4,7 @@ package tgb
 //
 // Telegram Bot API version: 9.4
 // Release date: February 9, 2026
-// Spec hash: 17154abd0187
+// Spec hash: 71c87c28d105
 
 import (
 	"context"

--- a/tgb/router_gen.go
+++ b/tgb/router_gen.go
@@ -4,7 +4,7 @@ package tgb
 //
 // Telegram Bot API version: 9.4
 // Release date: February 9, 2026
-// Spec hash: 17154abd0187
+// Spec hash: 71c87c28d105
 
 import "github.com/mr-linch/go-tg"
 

--- a/tgb/update_gen.go
+++ b/tgb/update_gen.go
@@ -4,7 +4,7 @@ package tgb
 //
 // Telegram Bot API version: 9.4
 // Release date: February 9, 2026
-// Spec hash: 17154abd0187
+// Spec hash: 71c87c28d105
 
 import "github.com/mr-linch/go-tg"
 

--- a/types_gen.go
+++ b/types_gen.go
@@ -4,7 +4,7 @@ package tg
 //
 // Telegram Bot API version: 9.4
 // Release date: February 9, 2026
-// Spec hash: 17154abd0187
+// Spec hash: 71c87c28d105
 
 import (
 	"encoding/json"
@@ -697,7 +697,9 @@ type Message struct {
 	// Optional. Service message: data sent by a Web App
 	WebAppData *WebAppData `json:"web_app_data,omitempty"`
 
-	// Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
+	// Optional. [Inline keyboard] attached to the message. login_url buttons are represented as ordinary url buttons.
+	//
+	// [Inline keyboard]: https://core.telegram.org/bots/features#inline-keyboards
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
@@ -4122,7 +4124,9 @@ type InlineQueryResultDocument struct {
 	// Optional. Short description of the result
 	Description string `json:"description,omitempty"`
 
-	// Optional. Inline keyboard attached to the message
+	// Optional. [Inline keyboard] attached to the message
+	//
+	// [Inline keyboard]: https://core.telegram.org/bots/features#inline-keyboards
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 
 	// Optional. Content of the message to be sent instead of the file
@@ -5279,7 +5283,7 @@ type Game struct {
 type CallbackGame struct{}
 
 // GameHighScore this object represents one row of the high scores table for a game.
-// And that's about all we've got for now. If you've got any questions, please check out our [Bot FAQ »] -
+// And that's about all we've got for now. If you've got any questions, please check out our [Bot FAQ »]
 //
 // [Bot FAQ »]: https://core.telegram.org/bots/faq
 type GameHighScore struct {


### PR DESCRIPTION
Automated update of Telegram Bot API specification.

- Version: 9.4
- Hash: 71c87c28d105

This PR was created automatically by the autogen workflow.